### PR TITLE
Validate webhook signatures against receipt time to allow retries

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -1,11 +1,86 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use chrono::{TimeDelta, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 
 use crate::db::QueueMessage;
 use crate::prelude::*;
 use crate::services::AppServices;
+
+/// Contextual information about the job being processed, derived from the
+/// original [`QueueMessage`] that triggered it.
+///
+/// In addition to providing access to the application [`Services`], this
+/// carries metadata about the originally enqueued message - most importantly
+/// the [`JobContext::scheduled_at`] timestamp. For webhook-backed jobs this is
+/// the time at which the request was received, which allows time-sensitive
+/// validation (such as webhook signature timestamp checks) to be performed
+/// against the original receipt time rather than the current time, so that
+/// retries continue to succeed.
+pub struct JobContext<S>
+where
+    S: Services + Send + Sync + 'static,
+{
+    services: S,
+    scheduled_at: DateTime<Utc>,
+    #[allow(dead_code)]
+    traceparent: Option<String>,
+    #[allow(dead_code)]
+    tracestate: Option<String>,
+}
+
+impl<S> JobContext<S>
+where
+    S: Services + Send + Sync + 'static,
+{
+    pub fn new(
+        services: S,
+        scheduled_at: DateTime<Utc>,
+        traceparent: Option<String>,
+        tracestate: Option<String>,
+    ) -> Self {
+        Self {
+            services,
+            scheduled_at,
+            traceparent,
+            tracestate,
+        }
+    }
+
+    /// The application services available to the job.
+    pub fn services(&self) -> &S {
+        &self.services
+    }
+
+    /// Consumes the context, returning ownership of the services. Useful when a
+    /// handler needs to pass owned services to a helper.
+    pub fn into_services(self) -> S {
+        self.services
+    }
+
+    /// The time at which the underlying message was originally enqueued.
+    ///
+    /// For webhook-backed jobs this is the time the request was received, which
+    /// makes it the correct reference point for validating time-sensitive
+    /// signatures even when a job is retried some time later.
+    pub fn scheduled_at(&self) -> DateTime<Utc> {
+        self.scheduled_at
+    }
+
+    /// The W3C `traceparent` associated with the originally enqueued message, if
+    /// any.
+    #[allow(dead_code)]
+    pub fn traceparent(&self) -> Option<&str> {
+        self.traceparent.as_deref()
+    }
+
+    /// The W3C `tracestate` associated with the originally enqueued message, if
+    /// any.
+    #[allow(dead_code)]
+    pub fn tracestate(&self) -> Option<&str> {
+        self.tracestate.as_deref()
+    }
+}
 
 pub trait Job {
     type JobType: Serialize + DeserializeOwned + Send + 'static;
@@ -66,8 +141,8 @@ pub trait Job {
 
     fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> impl std::future::Future<Output = Result<(), human_errors::Error>> + Send;
 
     fn job_hash(&self, job: &Self::JobType) -> Result<String, human_errors::Error> {
@@ -105,8 +180,8 @@ pub trait JobRunnable: Send + Sync {
     /// Deserialize the raw queue payload and run the underlying [`Job::handle`].
     async fn handle(
         &self,
+        ctx: JobContext<AppServices>,
         payload: &serde_json::Value,
-        services: AppServices,
     ) -> Result<(), human_errors::Error>;
 }
 
@@ -133,8 +208,8 @@ where
 
     async fn handle(
         &self,
+        ctx: JobContext<AppServices>,
         payload: &serde_json::Value,
-        services: AppServices,
     ) -> Result<(), human_errors::Error> {
         let job = <J::JobType as serde::Deserialize>::deserialize(payload).wrap_user_err(
             "Failed to deserialize the job payload into the type expected by its handler.",
@@ -144,7 +219,7 @@ where
             ],
         )?;
 
-        Job::handle(self, &job, services).await
+        Job::handle(self, ctx, &job).await
     }
 }
 
@@ -293,8 +368,15 @@ impl JobHost {
 
         debug!("Processing job '{name}' (traceparent: {traceparent}).");
 
+        let ctx = JobContext::new(
+            services,
+            item.scheduled_at,
+            item.traceparent.clone(),
+            item.tracestate.clone(),
+        );
+
         match handler
-            .handle(&item.payload, services)
+            .handle(ctx, &item.payload)
             .instrument(span.clone())
             .await
         {
@@ -377,10 +459,10 @@ mod tests {
 
         async fn handle(
             &self,
+            ctx: JobContext<impl Services + Send + Sync + 'static>,
             job: &Self::JobType,
-            services: impl Services + Send + Sync + 'static,
         ) -> Result<(), human_errors::Error> {
-            services
+            ctx.services()
                 .kv()
                 .set("test/dynamic-dispatch", job.id.clone(), job.value.clone())
                 .await?;
@@ -417,9 +499,13 @@ mod tests {
         let services = ServicesContainer::new_mock().await.unwrap();
 
         let payload = serde_json::json!({ "id": "k1", "value": "v1" });
-        JobRunnable::handle(&TestJob, &payload, services.clone())
-            .await
-            .unwrap();
+        JobRunnable::handle(
+            &TestJob,
+            JobContext::new(services.clone(), Utc::now(), None, None),
+            &payload,
+        )
+        .await
+        .unwrap();
 
         let stored: Option<String> = services
             .kv()

--- a/src/jobs/calendar.rs
+++ b/src/jobs/calendar.rs
@@ -50,15 +50,16 @@ impl Job for CalendarWorkflow {
         CronJob::schedule(&config.workflows.calendars, services).await
     }
 
-    #[instrument("workflow.calendar.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.calendar.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let collector = CalendarCollector::new(&job.url);
 
-        let items = collector.diff(&services).await?;
+        let items = collector.diff(services).await?;
 
         for item in items.into_iter() {
             match item {
@@ -67,9 +68,8 @@ impl Job for CalendarWorkflow {
                         "Calendar item '{}' matched filter, creating Todoist task",
                         item.summary
                     );
-                    let identifier_string = serde_json::to_string(&id).or_system_err(&[
-                        "Report this issue to the development team on GitHub.",
-                    ])?;
+                    let identifier_string = serde_json::to_string(&id)
+                        .or_system_err(&["Report this issue to the development team on GitHub."])?;
                     crate::publishers::TodoistUpsertTask::dispatch(
                         crate::publishers::TodoistUpsertTaskPayload {
                             unique_key: identifier_string,
@@ -85,7 +85,7 @@ impl Job for CalendarWorkflow {
                             config: job.todoist.clone(),
                         },
                         None,
-                        &services,
+                        services,
                     )
                     .await?;
                 }
@@ -94,30 +94,28 @@ impl Job for CalendarWorkflow {
                         "Calendar item '{}' did not match filter, skipping Todoist creation",
                         item.summary
                     );
-                    let identifier_string = serde_json::to_string(&id).or_system_err(&[
-                        "Report this issue to the development team on GitHub.",
-                    ])?;
+                    let identifier_string = serde_json::to_string(&id)
+                        .or_system_err(&["Report this issue to the development team on GitHub."])?;
                     crate::publishers::TodoistCompleteTask::dispatch(
                         crate::publishers::TodoistCompleteTaskPayload {
                             unique_key: identifier_string,
                             config: job.todoist.clone(),
                         },
                         None,
-                        &services,
+                        services,
                     )
                     .await?;
                 }
                 Diff::Removed(id) => {
-                    let identifier_string = serde_json::to_string(&id).or_system_err(&[
-                        "Report this issue to the development team on GitHub.",
-                    ])?;
+                    let identifier_string = serde_json::to_string(&id)
+                        .or_system_err(&["Report this issue to the development team on GitHub."])?;
                     crate::publishers::TodoistCompleteTask::dispatch(
                         crate::publishers::TodoistCompleteTaskPayload {
                             unique_key: identifier_string,
                             config: job.todoist.clone(),
                         },
                         None,
-                        &services,
+                        services,
                     )
                     .await?;
                 }

--- a/src/jobs/cron.rs
+++ b/src/jobs/cron.rs
@@ -88,20 +88,18 @@ impl Job for CronJob {
         false
     }
 
-    #[instrument("workflow.cron.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.cron.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let now = Utc::now();
-        let next_run = job
-            .cron
-            .find_next_occurrence(&now, false)
-            .wrap_user_err(
-                "We could not determine the next time at which this cron job should be dispatched.",
-                &["Please ensure the cron schedule is valid."],
-            )?;
+        let next_run = job.cron.find_next_occurrence(&now, false).wrap_user_err(
+            "We could not determine the next time at which this cron job should be dispatched.",
+            &["Please ensure the cron schedule is valid."],
+        )?;
 
         // Enqueue the job to be run at the next scheduled time
         services

--- a/src/jobs/github_notifications.rs
+++ b/src/jobs/github_notifications.rs
@@ -151,24 +151,26 @@ impl Job for GitHubNotificationsWorkflow {
         CronJob::schedule(&config.workflows.github_notifications, services).await
     }
 
-    #[instrument("workflow.github_notifications.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.github_notifications.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
         // Handle delayed auto-close checks
         if let Some(event) = job.event.as_ref() {
+            let services = ctx.services();
+
             // Check the status of the subject to see if it's still open/active/etc.
             let collector = GitHubNotificationsCollector::new();
-            let subject = collector.get_subject(&event.subject, &services).await?;
+            let subject = collector.get_subject(&event.subject, services).await?;
 
             match subject {
                 None => {
                     TodoistUpsertTask::dispatch(
                         self.build_task(event, job, None),
                         Some(event.id.clone().into()),
-                        &services,
+                        services,
                     )
                     .await?
                 }
@@ -176,13 +178,13 @@ impl Job for GitHubNotificationsWorkflow {
                     TodoistUpsertTask::dispatch(
                         self.build_task(event, job, Some(subject)),
                         Some(event.id.clone().into()),
-                        &services,
+                        services,
                     )
                     .await?
                 }
                 _ => {
                     // Closed/Resolved/Merged/etc., mark as done
-                    collector.mark_as_done(&event.id, &services).await?;
+                    collector.mark_as_done(&event.id, services).await?;
                     TodoistCompleteTask::dispatch(
                         #[allow(clippy::needless_update)]
                         TodoistCompleteTaskPayload {
@@ -191,7 +193,7 @@ impl Job for GitHubNotificationsWorkflow {
                             ..Default::default()
                         },
                         Some(event.id.clone().into()),
-                        &services,
+                        services,
                     )
                     .await?;
                 }
@@ -199,7 +201,8 @@ impl Job for GitHubNotificationsWorkflow {
 
             Ok(())
         } else {
-            self.collect_new_notifications(job, services).await
+            self.collect_new_notifications(job, ctx.into_services())
+                .await
         }
     }
 }

--- a/src/jobs/github_notifications_cleanup.rs
+++ b/src/jobs/github_notifications_cleanup.rs
@@ -50,12 +50,13 @@ impl Job for GitHubNotificationsCleanupWorkflow {
 
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let collector = GitHubNotificationsCollector::new();
 
-        let (notifications, _) = collector.fetch_since(None, &services).await?;
+        let (notifications, _) = collector.fetch_since(None, services).await?;
 
         for notification in notifications {
             if !job.filter.matches(&notification)? {
@@ -63,11 +64,11 @@ impl Job for GitHubNotificationsCleanupWorkflow {
             }
 
             if let Some(subject) = collector
-                .get_subject(&notification.subject, &services)
+                .get_subject(&notification.subject, services)
                 .await?
                 && !subject.is_open()
             {
-                collector.mark_as_done(&notification.id, &services).await?;
+                collector.mark_as_done(&notification.id, services).await?;
             }
         }
 

--- a/src/jobs/github_releases.rs
+++ b/src/jobs/github_releases.rs
@@ -44,15 +44,16 @@ impl Job for GitHubReleasesWorkflow {
         CronJob::schedule(&config.workflows.github_releases, services).await
     }
 
-    #[instrument("workflow.github_releases.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.github_releases.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let collector = GitHubReleasesCollector::new(&job.repository);
 
-        let items = collector.list(&services).await?;
+        let items = collector.list(services).await?;
 
         for item in items.into_iter() {
             match job.filter.matches(&item) {
@@ -80,7 +81,7 @@ impl Job for GitHubReleasesWorkflow {
                     ..Default::default()
                 },
                 None,
-                &services,
+                services,
             )
             .await?;
         }

--- a/src/jobs/rss.rs
+++ b/src/jobs/rss.rs
@@ -57,12 +57,13 @@ impl Job for RssWorkflow {
         CronJob::schedule(&config.workflows.rss, services).await
     }
 
-    #[instrument("workflow.rss.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.rss.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let base_url: reqwest::Url = job.homepage.parse().wrap_user_err(
             format!("The feed URL you provided could not be parsed as a valid URL ({}).", &job.homepage),
             &[
@@ -71,7 +72,7 @@ impl Job for RssWorkflow {
 
         let collector = RssCollector::new(&job.url);
 
-        let items = collector.list(&services).await?;
+        let items = collector.list(services).await?;
 
         for item in items.into_iter() {
             match job.filter.matches(&RssEntryFilter(&item)) {
@@ -111,7 +112,7 @@ impl Job for RssWorkflow {
                     ..Default::default()
                 },
                 None,
-                &services,
+                services,
             )
             .await?;
         }

--- a/src/jobs/spotify_yearly_playlist.rs
+++ b/src/jobs/spotify_yearly_playlist.rs
@@ -20,10 +20,11 @@ impl Job for SpotifyYearlyPlaylistWorkflow {
 
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
-        let token = SpotifyClient::renew_access_token(job, &services).await?;
+        let services = ctx.services();
+        let token = SpotifyClient::renew_access_token(job, services).await?;
 
         let client = SpotifyClient::new(token.clone());
         let user = client.get_current_user().await?;
@@ -31,7 +32,7 @@ impl Job for SpotifyYearlyPlaylistWorkflow {
         let collector =
             crate::collectors::SpotifyLikedTracksCollector::new(user.id.clone(), token.clone());
 
-        let new_tracks = collector.list(&services).await?;
+        let new_tracks = collector.list(services).await?;
 
         if !new_tracks.is_empty() {
             let year_groups =
@@ -60,13 +61,13 @@ impl Job for SpotifyYearlyPlaylistWorkflow {
                         track_uris: tracks.iter().map(|t| t.track.uri.clone()).collect(),
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
             }
         }
 
-        Self::dispatch_delayed(token, Some(user.id.into()), TimeDelta::hours(1), &services).await?;
+        Self::dispatch_delayed(token, Some(user.id.into()), TimeDelta::hours(1), services).await?;
 
         Ok(())
     }

--- a/src/jobs/todoist_cleanup.rs
+++ b/src/jobs/todoist_cleanup.rs
@@ -51,15 +51,16 @@ impl Job for TodoistCleanupWorkflow {
 
     #[instrument(
         "workflow.todoist_cleanup.handle",
-        skip(self, job, services),
+        skip(self, ctx, job),
         fields(job = %job),
         err(Display)
     )]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let config = services.config().connections.todoist.merge(&job.todoist);
         let client = TodoistClient::new(&config)?;
 

--- a/src/jobs/xkcd.rs
+++ b/src/jobs/xkcd.rs
@@ -47,15 +47,16 @@ impl Job for XkcdWorkflow {
         CronJob::schedule(&config.workflows.xkcd, services).await
     }
 
-    #[instrument("workflow.xkcd.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.xkcd.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let collector = XkcdCollector::new();
 
-        let items = collector.list(&services).await?;
+        let items = collector.list(services).await?;
 
         for item in items.into_iter() {
             match job.filter.matches(&item) {
@@ -81,7 +82,7 @@ impl Job for XkcdWorkflow {
                     ..Default::default()
                 },
                 None,
-                &services,
+                services,
             )
             .await?;
         }

--- a/src/jobs/youtube.rs
+++ b/src/jobs/youtube.rs
@@ -48,15 +48,16 @@ impl Job for YouTubeWorkflow {
         CronJob::schedule(&config.workflows.youtube, services).await
     }
 
-    #[instrument("workflow.youtube.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("workflow.youtube.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let collector = YouTubeCollector::new(&job.channel_id);
 
-        let items = collector.list(&services).await?;
+        let items = collector.list(services).await?;
 
         for item in items.into_iter() {
             match job.filter.matches(&item) {
@@ -84,7 +85,7 @@ impl Job for YouTubeWorkflow {
                     ..Default::default()
                 },
                 None,
-                &services,
+                services,
             )
             .await?;
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@ pub use crate::collectors::Collector;
 pub use crate::config::{Config, Mergeable};
 pub use crate::db::{Cache, KeyValueStore, Queue};
 pub use crate::filter::{Filter, Filterable};
-pub use crate::job::Job;
+pub use crate::job::{Job, JobContext};
 pub use crate::jobs::CronJob;
 pub use crate::services::Services;
 pub use crate::web::OAuth2RefreshToken;

--- a/src/publishers/spotify_add_to_playlist.rs
+++ b/src/publishers/spotify_add_to_playlist.rs
@@ -24,17 +24,17 @@ impl Job for SpotifyAddToPlaylist {
 
     #[instrument(
         "publishers.spotify_add_to_playlist.handle",
-        skip(self, job, services),
+        skip(self, ctx, job),
         err(Display)
     )]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
         let client = SpotifyClient::new(job.access_token.clone());
 
-        let playlist_id = self.get_playlist_id(job, &services).await?;
+        let playlist_id = self.get_playlist_id(job, ctx.services()).await?;
 
         for chunk in job.track_uris.chunks(100) {
             client

--- a/src/publishers/todoist_complete.rs
+++ b/src/publishers/todoist_complete.rs
@@ -23,14 +23,15 @@ impl Job for TodoistCompleteTask {
 
     #[instrument(
         "publishers.todoist_complete.handle",
-        skip(self, job, services),
+        skip(self, ctx, job),
         err(Display)
     )]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let config = services.config().connections.todoist.merge(&job.config);
 
         let client = TodoistClient::new(&config)?;

--- a/src/publishers/todoist_create.rs
+++ b/src/publishers/todoist_create.rs
@@ -24,29 +24,26 @@ impl Job for TodoistCreateTask {
         "todoist/create-task"
     }
 
-    #[instrument(
-        "publishers.todoist_create.handle",
-        skip(self, job, services),
-        err(Display)
-    )]
+    #[instrument("publishers.todoist_create.handle", skip(self, ctx, job), err(Display))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let config = services.config().connections.todoist.merge(&job.config);
 
         let client = TodoistClient::new(&config)?;
 
         let project_id = client
-            .get_project_id(config.project.as_deref().unwrap_or("Inbox"), &services)
+            .get_project_id(config.project.as_deref().unwrap_or("Inbox"), services)
             .await?;
         let section_id = client
             .get_section_id(
                 config.project.as_deref().unwrap_or("Inbox"),
                 &project_id,
                 config.section.as_deref(),
-                &services,
+                services,
             )
             .await?;
 

--- a/src/publishers/todoist_upsert.rs
+++ b/src/publishers/todoist_upsert.rs
@@ -33,16 +33,13 @@ impl Job for TodoistUpsertTask {
         "todoist/upsert-task"
     }
 
-    #[instrument(
-        "publishers.todoist_upsert.handle",
-        skip(self, job, services),
-        err(Display)
-    )]
+    #[instrument("publishers.todoist_upsert.handle", skip(self, ctx, job), err(Display))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
         let config = services.config().connections.todoist.merge(&job.config);
 
         let client = TodoistClient::new(&config)?;
@@ -101,14 +98,14 @@ impl Job for TodoistUpsertTask {
                 .await?;
         } else {
             let project_id = client
-                .get_project_id(config.project.as_deref().unwrap_or("Inbox"), &services)
+                .get_project_id(config.project.as_deref().unwrap_or("Inbox"), services)
                 .await?;
             let section_id = client
                 .get_section_id(
                     config.project.as_deref().unwrap_or("Inbox"),
                     &project_id,
                     config.section.as_deref(),
-                    &services,
+                    services,
                 )
                 .await?;
 

--- a/src/webhooks/azure_monitor.rs
+++ b/src/webhooks/azure_monitor.rs
@@ -38,12 +38,14 @@ impl Job for AzureMonitorWebhook {
         "webhooks/azure-monitor"
     }
 
-    #[instrument("webhooks.azure_monitor.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.azure_monitor.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         let event: AzureMonitorAlertEventPayload = job.json()?;
 
         match event.data.essentials.monitor_condition {
@@ -69,7 +71,7 @@ impl Job for AzureMonitorWebhook {
                         priority: Some(event.data.essentials.severity.priority()),
                         config: services.config().webhooks.azure_monitor.todoist.clone(),
                         ..Default::default()
-                    }, None, &services).await?;
+                    }, None, services).await?;
 
                 Ok(())
             }
@@ -82,7 +84,7 @@ impl Job for AzureMonitorWebhook {
                         ..Default::default()
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
                 Ok(())

--- a/src/webhooks/grafana.rs
+++ b/src/webhooks/grafana.rs
@@ -46,12 +46,14 @@ impl Job for GrafanaWebhook {
         "webhooks/grafana"
     }
 
-    #[instrument("webhooks.grafana.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.grafana.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         // Validate the authorization header if a secret is configured
         if let Some(expected_secret) = &services.config().webhooks.grafana.secret {
             if !expected_secret.is_empty() {
@@ -160,7 +162,7 @@ impl Job for GrafanaWebhook {
                         due: starts_at
                             .map(crate::publishers::TodoistDueDate::DateTime)
                             .unwrap_or_else(|| {
-                                crate::publishers::TodoistDueDate::DateTime(Utc::now())
+                                crate::publishers::TodoistDueDate::DateTime(ctx.scheduled_at())
                             }),
                         priority: Some(priority),
                         config: services.config().webhooks.grafana.todoist.clone(),
@@ -173,7 +175,7 @@ impl Job for GrafanaWebhook {
                             .unwrap_or_else(|| event.title.clone())
                             .into(),
                     ),
-                    &services,
+                    services,
                 )
                 .await?;
 
@@ -192,7 +194,7 @@ impl Job for GrafanaWebhook {
                         config: services.config().webhooks.grafana.todoist.clone(),
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
 
@@ -364,7 +366,9 @@ mod tests {
             headers: HashMap::new(),
         };
 
-        let result = webhook.handle(&event, services).await;
+        let result = webhook
+            .handle(JobContext::new(services, Utc::now(), None, None), &event)
+            .await;
         assert!(result.is_ok(), "Webhook should handle firing alert");
     }
 
@@ -408,7 +412,9 @@ mod tests {
             headers: HashMap::new(),
         };
 
-        let result = webhook.handle(&event, services).await;
+        let result = webhook
+            .handle(JobContext::new(services, Utc::now(), None, None), &event)
+            .await;
         assert!(result.is_ok(), "Webhook should handle resolved alert");
     }
 
@@ -425,7 +431,9 @@ mod tests {
             headers: HashMap::new(),
         };
 
-        let result = webhook.handle(&event, services).await;
+        let result = webhook
+            .handle(JobContext::new(services, Utc::now(), None, None), &event)
+            .await;
         assert!(result.is_err(), "Webhook should reject invalid JSON");
     }
 

--- a/src/webhooks/honeycomb.rs
+++ b/src/webhooks/honeycomb.rs
@@ -35,12 +35,14 @@ impl Job for HoneycombWebhook {
         "webhooks/honeycomb"
     }
 
-    #[instrument("webhooks.honeycomb.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.honeycomb.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         if let Some(secret) = job.headers.get("X-Honeycomb-Webhook-Token") {
             if !services
                 .config()
@@ -102,13 +104,13 @@ impl Job for HoneycombWebhook {
                     event.name
                 ),
                 description: event.description,
-                due: TodoistDueDate::DateTime(chrono::Utc::now()),
+                due: TodoistDueDate::DateTime(ctx.scheduled_at()),
                 priority: Some(4),
                 config: services.config().webhooks.honeycomb.todoist.clone(),
                 ..Default::default()
             },
             None,
-            &services,
+            services,
         )
         .await?;
 

--- a/src/webhooks/sentry.rs
+++ b/src/webhooks/sentry.rs
@@ -85,12 +85,14 @@ impl Job for SentryAlertsWebhook {
         "webhooks/sentry"
     }
 
-    #[instrument("webhooks.sentry.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.sentry.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         // Validate the Sentry webhook signature header
         // https://docs.sentry.io/organization/integrations/integration-platform/webhooks/
         let secret = &services.config().webhooks.sentry.secret;
@@ -151,13 +153,13 @@ impl Job for SentryAlertsWebhook {
                             issue.short_id, issue.web_url, issue.title
                         ),
                         description: Some(issue.culprit.clone()),
-                        due: TodoistDueDate::DateTime(chrono::Utc::now()),
+                        due: TodoistDueDate::DateTime(ctx.scheduled_at()),
                         priority: Some(issue.level.to_priority()),
                         config: services.config().webhooks.sentry.todoist.clone(),
                         ..Default::default()
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
             }
@@ -183,13 +185,13 @@ impl Job for SentryAlertsWebhook {
                             alert.project_slug, alert.url, alert.title()
                         ),
                         description: Some(alert.culprit.clone()),
-                        due: TodoistDueDate::DateTime(chrono::Utc::now()),
+                        due: TodoistDueDate::DateTime(ctx.scheduled_at()),
                         priority: Some(alert.level.to_priority()),
                         config: services.config().webhooks.sentry.todoist.clone(),
                         ..Default::default()
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
             }

--- a/src/webhooks/tailscale.rs
+++ b/src/webhooks/tailscale.rs
@@ -83,14 +83,20 @@ impl TailscaleWebhook {
     /// Tailscale signs webhooks using HMAC-SHA256 with the webhook secret, and includes
     /// the signature in the Tailscale-Webhook-Signature header in the format:
     /// `t=<timestamp>,v1=<hex_signature>`
+    ///
+    /// The `now` parameter is the point in time against which the signature
+    /// timestamp is validated. This should be the time at which the request was
+    /// originally received (rather than the current time) so that retries of a
+    /// previously received request continue to validate successfully.
     fn verify_signature(
         secret: &str,
         body: &str,
         signature_header: &str,
+        now: DateTime<Utc>,
     ) -> Result<(), human_errors::Error> {
         let (timestamp, expected_signature) = Self::parse_signature(signature_header)?;
 
-        if (timestamp - Utc::now()).abs() > chrono::Duration::minutes(5) {
+        if (timestamp - now).abs() > chrono::Duration::minutes(5) {
             return Err(human_errors::user(
                 format!(
                     "The Tailscale webhook signature timestamp is too old or too far in the future (got {})",
@@ -139,12 +145,14 @@ impl Job for TailscaleWebhook {
         "webhooks/tailscale"
     }
 
-    #[instrument("webhooks.tailscale.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.tailscale.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         // Validate the Tailscale webhook signature header
         // https://tailscale.com/kb/1213/webhooks#verifying-an-event-signature
         let secret = &services.config().webhooks.tailscale.secret;
@@ -158,7 +166,12 @@ impl Job for TailscaleWebhook {
                 .map(|(_, value)| value.as_str());
 
             if let Some(signature) = signature {
-                if let Err(err) = Self::verify_signature(secret, &job.body, signature) {
+                // Validate the signature against the time the request was
+                // originally received (the message's scheduled time) so that
+                // retries of a previously received webhook continue to validate.
+                if let Err(err) =
+                    Self::verify_signature(secret, &job.body, signature, ctx.scheduled_at())
+                {
                     warn!(
                         "Failed to verify Tailscale webhook signature, rejecting request: {}",
                         err
@@ -229,7 +242,7 @@ impl Job for TailscaleWebhook {
                 ..Default::default()
             },
             None,
-            &services,
+            services,
         )
         .await?;
 
@@ -283,8 +296,32 @@ mod tests {
         let body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Test message","data":{}}"#;
         let signature = generate_signature(secret, &timestamp, body);
 
-        let result = TailscaleWebhook::verify_signature(secret, body, &signature);
+        let result = TailscaleWebhook::verify_signature(secret, body, &signature, Utc::now());
         result.expect("Valid signature should verify successfully");
+    }
+
+    #[test]
+    fn test_verify_signature_valid_on_retry() {
+        // Simulates a retry: the signature timestamp is well outside the
+        // five-minute window relative to the current time, but validation is
+        // performed against the time the request was originally received, so it
+        // should still succeed.
+        let secret = "test_secret_key";
+        let received_at = Utc::now() - chrono::Duration::hours(6);
+        let timestamp = received_at.timestamp().to_string();
+        let body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Test message","data":{}}"#;
+        let signature = generate_signature(secret, &timestamp, body);
+
+        // Validating against the current time should fail (too old).
+        let result = TailscaleWebhook::verify_signature(secret, body, &signature, Utc::now());
+        assert!(
+            result.is_err(),
+            "Signature should be rejected when validated against the current time"
+        );
+
+        // Validating against the original receipt time should succeed.
+        let result = TailscaleWebhook::verify_signature(secret, body, &signature, received_at);
+        result.expect("Signature should verify against the original receipt time on retry");
     }
 
     #[test]
@@ -294,7 +331,7 @@ mod tests {
         let wrong_signature =
             "t=1663781880,v1=0000000000000000000000000000000000000000000000000000000000000000";
 
-        let result = TailscaleWebhook::verify_signature(secret, body, wrong_signature);
+        let result = TailscaleWebhook::verify_signature(secret, body, wrong_signature, Utc::now());
         assert!(
             result.is_err(),
             "Invalid signature should fail verification"
@@ -309,7 +346,7 @@ mod tests {
         let body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Test message","data":{}}"#;
         let signature = generate_signature(wrong_secret, &timestamp, body);
 
-        let result = TailscaleWebhook::verify_signature(secret, body, &signature);
+        let result = TailscaleWebhook::verify_signature(secret, body, &signature, Utc::now());
         assert!(
             result.is_err(),
             "Signature with wrong secret should fail verification"
@@ -324,7 +361,8 @@ mod tests {
         let tampered_body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Tampered message","data":{}}"#;
         let signature = generate_signature(secret, &timestamp, original_body);
 
-        let result = TailscaleWebhook::verify_signature(secret, tampered_body, &signature);
+        let result =
+            TailscaleWebhook::verify_signature(secret, tampered_body, &signature, Utc::now());
         assert!(result.is_err(), "Tampered body should fail verification");
     }
 
@@ -334,7 +372,7 @@ mod tests {
         let body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Test message","data":{}}"#;
         let invalid_format = "not_a_valid_format";
 
-        let result = TailscaleWebhook::verify_signature(secret, body, invalid_format);
+        let result = TailscaleWebhook::verify_signature(secret, body, invalid_format, Utc::now());
         assert!(result.is_err(), "Invalid format should fail");
     }
 
@@ -345,7 +383,8 @@ mod tests {
         let missing_timestamp =
             "v1=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-        let result = TailscaleWebhook::verify_signature(secret, body, missing_timestamp);
+        let result =
+            TailscaleWebhook::verify_signature(secret, body, missing_timestamp, Utc::now());
         assert!(result.is_err(), "Missing timestamp should fail");
     }
 
@@ -355,7 +394,8 @@ mod tests {
         let body = r#"{"version":1,"timestamp":"2024-01-01T00:00:00Z","type":"test","tailnet":"example.com","message":"Test message","data":{}}"#;
         let missing_signature = "t=1663781880";
 
-        let result = TailscaleWebhook::verify_signature(secret, body, missing_signature);
+        let result =
+            TailscaleWebhook::verify_signature(secret, body, missing_signature, Utc::now());
         assert!(result.is_err(), "Missing signature should fail");
     }
 
@@ -366,7 +406,7 @@ mod tests {
         let body = "";
         let signature = generate_signature(secret, &timestamp, body);
 
-        let result = TailscaleWebhook::verify_signature(secret, body, &signature);
+        let result = TailscaleWebhook::verify_signature(secret, body, &signature, Utc::now());
         result.expect("Empty body with valid signature should verify successfully");
     }
 

--- a/src/webhooks/terraform.rs
+++ b/src/webhooks/terraform.rs
@@ -35,12 +35,14 @@ impl Job for TerraformWebhook {
         "webhooks/terraform"
     }
 
-    #[instrument("webhooks.terraform.handle", skip(self, job, services), fields(job = %job))]
+    #[instrument("webhooks.terraform.handle", skip(self, ctx, job), fields(job = %job))]
     async fn handle(
         &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
-        services: impl Services + Send + Sync + 'static,
     ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+
         if let Some(secret) = services.config().webhooks.terraform.secret.as_ref() {
             let expected_hash = job.headers.get("X-TFE-Notification-Signature")
                 .ok_or_else(|| human_errors::user("Missing X-TFE-Notification-Signature header in Terraform webhook", &[
@@ -107,7 +109,7 @@ impl Job for TerraformWebhook {
                         ..Default::default()
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
             }
@@ -133,7 +135,7 @@ impl Job for TerraformWebhook {
                         ..Default::default()
                     },
                     None,
-                    &services,
+                    services,
                 )
                 .await?;
             }


### PR DESCRIPTION
Introduce a JobContext that carries the originally-enqueued message's metadata (scheduled time, traceparent/tracestate) alongside the services, and change the job calling convention to handle(&self, ctx, job).

Webhook signature timestamp checks now validate against the time the request was received (the message's scheduled_at) rather than Utc::now(), so retries of a previously received webhook no longer fail the freshness window. Time-sensitive Todoist due dates likewise use scheduled_at for stable retries.