### PR TITLE
refactor: Use a shared HTTP client across collectors and publishers

### DIFF
--- a/src/collectors/calendar.rs
+++ b/src/collectors/calendar.rs
@@ -61,14 +61,13 @@ impl DifferentialCollector for CalendarCollector {
         }
     }
 
-    #[instrument("collectors.calendar.fetch", skip(self), err(Display))]
-    async fn fetch(&self) -> Result<Vec<Self::Item>, human_errors::Error> {
-        let client = reqwest::Client::builder()
-            .user_agent("SierraSoftworks/automate-rs")
-            .build()
-            .or_system_err(&["Report this issue to the development team on GitHub."])?;
-
-        let response = client
+    #[instrument("collectors.calendar.fetch", skip(self, services), err(Display))]
+    async fn fetch(
+        &self,
+        services: &impl Services,
+    ) -> Result<Vec<Self::Item>, human_errors::Error> {
+        let response = services
+            .http_client()
             .get(&self.url)
             .header("Accept", "text/calendar")
             .send()

--- a/src/collectors/differential.rs
+++ b/src/collectors/differential.rs
@@ -18,7 +18,8 @@ pub trait DifferentialCollector: Collector {
 
     fn identifier(&self, item: &Self::Item) -> Self::Identifier;
 
-    async fn fetch(&self) -> Result<Vec<Self::Item>, human_errors::Error>;
+    async fn fetch(&self, services: &impl Services)
+    -> Result<Vec<Self::Item>, human_errors::Error>;
 
     #[allow(clippy::type_complexity)]
     #[instrument("collectors.diff", skip(self, services))]
@@ -29,7 +30,7 @@ pub trait DifferentialCollector: Collector {
         let partition = self.partition();
         let key = self.key();
 
-        let items = self.fetch().await?;
+        let items = self.fetch(services).await?;
 
         let old_identifiers: Vec<Self::Identifier> = services
             .kv()

--- a/src/collectors/github_notifications.rs
+++ b/src/collectors/github_notifications.rs
@@ -36,9 +36,7 @@ impl GitHubNotificationsCollector {
         services: &(impl crate::services::Services + Send + Sync + 'static),
     ) -> Result<Option<GitHubSubjectInformation>, human_errors::Error> {
         if let Some(url) = &subject.url {
-            let client = self.get_client(services)?;
-
-            let response = client.get(url)
+            let response = self.request(services, reqwest::Method::GET, url)
                 .send().await.wrap_user_err("We were unable to fetch GitHub notification subject state from GitHub.", &[
                     "Make sure that your network connection is working properly.",
                     "Check https://www.githubstatus.com/ for any ongoing issues with GitHub's services.",
@@ -101,10 +99,12 @@ impl GitHubNotificationsCollector {
         thread_id: &str,
         services: &(impl crate::services::Services + Send + Sync + 'static),
     ) -> Result<(), human_errors::Error> {
-        let client = self.get_client(services)?;
-
-        let response = client
-            .delete(format!("{}/notifications/threads/{}", self.api_url, thread_id))
+        let response = self
+            .request(
+                services,
+                reqwest::Method::DELETE,
+                format!("{}/notifications/threads/{}", self.api_url, thread_id),
+            )
             .send().await.wrap_user_err("We were unable to mark the GitHub notification as read.", &[
                 "Make sure that your network connection is working properly.",
                 "Check https://www.githubstatus.com/ for any ongoing issues with GitHub's services.",
@@ -134,29 +134,23 @@ impl GitHubNotificationsCollector {
         }
     }
 
-    fn get_client(
+    fn request(
         &self,
         services: &impl crate::services::Services,
-    ) -> Result<reqwest::Client, human_errors::Error> {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("X-GitHub-Api-Version", "2022-11-28".parse().unwrap());
-        headers.insert("Accept", "application/vnd.github+json".parse().unwrap());
+        method: reqwest::Method,
+        url: impl reqwest::IntoUrl,
+    ) -> reqwest::RequestBuilder {
+        let mut request = services
+            .http_client()
+            .request(method, url)
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("Accept", "application/vnd.github+json");
 
         if let Some(api_key) = services.config().connections.github.api_key.as_ref() {
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key))
-                    .or_system_err(&["Report the issue to the development team on GitHub."])?,
-            );
+            request = request.bearer_auth(api_key);
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent("SierraSoftworks/automate-rs")
-            .default_headers(headers)
-            .build()
-            .or_system_err(&["Report the issue to the development team on GitHub."])?;
-
-        Ok(client)
+        request
     }
 }
 
@@ -198,9 +192,7 @@ impl IncrementalCollector for GitHubNotificationsCollector {
         watermark: Option<Self::Watermark>,
         services: &impl crate::services::Services,
     ) -> Result<(Vec<Self::Item>, Self::Watermark), human_errors::Error> {
-        let client = self.get_client(services)?;
-
-        let response = client.get(format!("{}/notifications", self.api_url))
+        let response = self.request(services, reqwest::Method::GET, format!("{}/notifications", self.api_url))
             .header("If-Modified-Since", watermark.as_deref().unwrap_or("Thu, 01 Jan 1970 00:00:00 GMT"))
             .send().await.wrap_user_err("We were unable to fetch GitHub notifications from GitHub.", &[
                 "Make sure that your network connection is working properly.",

--- a/src/collectors/github_releases.rs
+++ b/src/collectors/github_releases.rs
@@ -95,24 +95,16 @@ impl IncrementalCollector for GitHubReleasesCollector {
         watermark: Option<Self::Watermark>,
         services: &impl crate::services::Services,
     ) -> Result<(Vec<Self::Item>, Self::Watermark), human_errors::Error> {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("X-GitHub-Api-Version", "2022-11-28".parse().unwrap());
+        let mut request = services
+            .http_client()
+            .get(format!("{}/repos/{}/releases", self.api_url, self.repo))
+            .header("X-GitHub-Api-Version", "2022-11-28");
 
         if let Some(api_key) = services.config().connections.github.api_key.as_ref() {
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key))
-                    .or_system_err(&["Report the issue to the development team on GitHub."])?,
-            );
+            request = request.bearer_auth(api_key);
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent("SierraSoftworks/automate-rs")
-            .default_headers(headers)
-            .build()
-            .or_system_err(&["Report the issue to the development team on GitHub."])?;
-
-        let response = client.get(format!("{}/repos/{}/releases", self.api_url, self.repo))
+        let response = request
             .send().await.wrap_user_err("We were unable to fetch GitHub releases from GitHub.", &[
                 "Make sure that your network connection is working properly.",
                 "Check https://www.githubstatus.com/ for any ongoing issues with GitHub's services.",

--- a/src/collectors/rss.rs
+++ b/src/collectors/rss.rs
@@ -41,13 +41,16 @@ impl IncrementalCollector for RssCollector {
         Cow::Owned(self.feed_url.clone())
     }
 
-    #[instrument("collectors.rss.fetch_since", skip(self, _services), err(Display))]
+    #[instrument("collectors.rss.fetch_since", skip(self, services), err(Display))]
     async fn fetch_since(
         &self,
         watermark: Option<Self::Watermark>,
-        _services: &impl crate::services::Services,
+        services: &impl crate::services::Services,
     ) -> Result<(Vec<Self::Item>, Self::Watermark), human_errors::Error> {
-        let content = reqwest::get(&self.feed_url)
+        let content = services
+            .http_client()
+            .get(&self.feed_url)
+            .send()
             .await
             .wrap_user_err(
                 format!("Failed to fetch RSS feed from URL '{}'.", &self.feed_url),

--- a/src/collectors/spotify_liked_tracks.rs
+++ b/src/collectors/spotify_liked_tracks.rs
@@ -41,15 +41,18 @@ impl IncrementalCollector for SpotifyLikedTracksCollector {
 
     #[instrument(
         "collectors.spotify_liked_tracks.fetch_since",
-        skip(self, _services),
+        skip(self, services),
         err(Display)
     )]
     async fn fetch_since(
         &self,
         watermark: Option<Self::Watermark>,
-        _services: &impl crate::services::Services,
+        services: &impl crate::services::Services,
     ) -> Result<(Vec<Self::Item>, Self::Watermark), human_errors::Error> {
-        let client = crate::publishers::spotify::SpotifyClient::new(self.access_token.clone());
+        let client = crate::publishers::spotify::SpotifyClient::new(
+            self.access_token.clone(),
+            services.http_client(),
+        );
 
         let since = watermark
             .unwrap_or_else(|| chrono::DateTime::<chrono::Utc>::from(std::time::UNIX_EPOCH));

--- a/src/jobs/spotify_yearly_playlist.rs
+++ b/src/jobs/spotify_yearly_playlist.rs
@@ -26,7 +26,7 @@ impl Job for SpotifyYearlyPlaylistWorkflow {
         let services = ctx.services();
         let token = SpotifyClient::renew_access_token(job, services).await?;
 
-        let client = SpotifyClient::new(token.clone());
+        let client = SpotifyClient::new(token.clone(), services.http_client());
         let user = client.get_current_user().await?;
 
         let collector =

--- a/src/publishers/spotify.rs
+++ b/src/publishers/spotify.rs
@@ -9,12 +9,12 @@ pub struct SpotifyClient {
 }
 
 impl SpotifyClient {
-    pub fn new(refresh_token: OAuth2RefreshToken) -> Self {
+    pub fn new(refresh_token: OAuth2RefreshToken, http_client: reqwest::Client) -> Self {
         SpotifyClient {
             api_endpoint: "https://api.spotify.com/v1".to_string(),
             refresh_token,
 
-            client: reqwest::Client::new(),
+            client: http_client,
         }
     }
 
@@ -204,7 +204,7 @@ impl SpotifyClient {
         services: &(impl Services + Send + Sync + 'static),
     ) -> Result<OAuth2RefreshToken, human_errors::Error> {
         let config = services.config().get_oauth2("spotify")?;
-        config.get_access_token(token).await
+        config.get_access_token(token, &services.http_client()).await
     }
 }
 

--- a/src/publishers/spotify_add_to_playlist.rs
+++ b/src/publishers/spotify_add_to_playlist.rs
@@ -32,7 +32,7 @@ impl Job for SpotifyAddToPlaylist {
         ctx: JobContext<impl Services + Send + Sync + 'static>,
         job: &Self::JobType,
     ) -> Result<(), human_errors::Error> {
-        let client = SpotifyClient::new(job.access_token.clone());
+        let client = SpotifyClient::new(job.access_token.clone(), ctx.services().http_client());
 
         let playlist_id = self.get_playlist_id(job, ctx.services()).await?;
 
@@ -62,7 +62,7 @@ impl SpotifyAddToPlaylist {
         {
             Ok(playlist_id)
         } else {
-            let client = SpotifyClient::new(job.access_token.clone());
+            let client = SpotifyClient::new(job.access_token.clone(), services.http_client());
 
             if let Some(playlist) = client
                 .get_playlists()

--- a/src/services.rs
+++ b/src/services.rs
@@ -10,6 +10,10 @@ use crate::config::Config;
 /// single concrete type to remain object-safe.
 pub type AppServices = ServicesContainer<crate::db::SqliteDatabase>;
 
+/// The user agent applied to the shared HTTP client used across collectors and
+/// publishers.
+pub const HTTP_USER_AGENT: &str = "SierraSoftworks/automate";
+
 pub trait Services
 where
     Self: Sized,
@@ -19,11 +23,19 @@ where
     fn kv(&self) -> impl crate::db::KeyValueStore + Clone + Send + Sync + 'static;
     fn queue(&self) -> impl crate::db::Queue + Clone + Send + Sync + 'static;
     fn cache(&self) -> impl crate::db::Cache + Clone + Send + Sync + 'static;
+
+    /// A shared [`reqwest::Client`] configured with the default user agent.
+    ///
+    /// Cloning a [`reqwest::Client`] is cheap and shares the underlying
+    /// connection pool, so collectors and publishers should prefer this over
+    /// constructing their own clients.
+    fn http_client(&self) -> reqwest::Client;
 }
 
 pub struct ServicesContainer<D: crate::db::KeyValueStore + crate::db::Queue + crate::db::Cache> {
     pub config: Arc<Config>,
     pub database: D,
+    pub http_client: reqwest::Client,
 }
 
 impl<D: crate::db::KeyValueStore + crate::db::Queue + crate::db::Cache + Clone> Clone
@@ -33,6 +45,7 @@ impl<D: crate::db::KeyValueStore + crate::db::Queue + crate::db::Cache + Clone> 
         Self {
             config: self.config.clone(),
             database: self.database.clone(),
+            http_client: self.http_client.clone(),
         }
     }
 }
@@ -42,9 +55,15 @@ where
     D: crate::db::KeyValueStore + crate::db::Queue + crate::db::Cache,
 {
     pub fn new(config: crate::config::Config, database: D) -> Self {
+        let http_client = reqwest::Client::builder()
+            .user_agent(HTTP_USER_AGENT)
+            .build()
+            .expect("Failed to build the default HTTP client.");
+
         Self {
             config: Arc::new(config),
             database,
+            http_client,
         }
     }
 }
@@ -82,5 +101,9 @@ where
 
     fn cache(&self) -> impl crate::db::Cache + Clone + Send + Sync + 'static {
         self.database.clone()
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        self.http_client.clone()
     }
 }

--- a/src/web/helpers/oidc.rs
+++ b/src/web/helpers/oidc.rs
@@ -161,6 +161,7 @@ pub async fn discovery<S: Services>(
 ) -> Result<OidcDiscovery, human_errors::Error> {
     let endpoint = oidc.endpoint.trim_end_matches('/').to_string();
     let fetch_endpoint = endpoint.clone();
+    let http_client = services.http_client();
 
     services
         .cache()
@@ -170,7 +171,7 @@ pub async fn discovery<S: Services>(
             move || {
                 Box::pin(async move {
                     let url = format!("{fetch_endpoint}/.well-known/openid-configuration");
-                    let document: OidcDiscovery = reqwest::Client::new()
+                    let document: OidcDiscovery = http_client
                         .get(&url)
                         .send()
                         .await
@@ -206,6 +207,7 @@ async fn jwks<S: Services>(
 ) -> Result<jsonwebtoken::jwk::JwkSet, human_errors::Error> {
     let jwks_uri = discovery.jwks_uri.clone();
     let fetch_uri = jwks_uri.clone();
+    let http_client = services.http_client();
 
     services
         .cache()
@@ -214,7 +216,7 @@ async fn jwks<S: Services>(
             jwks_uri,
             move || {
                 Box::pin(async move {
-                    let keys: jsonwebtoken::jwk::JwkSet = reqwest::Client::new()
+                    let keys: jsonwebtoken::jwk::JwkSet = http_client
                         .get(&fetch_uri)
                         .send()
                         .await
@@ -491,6 +493,7 @@ pub async fn exchange_code(
     discovery: &OidcDiscovery,
     code: &str,
     redirect_uri: &str,
+    http_client: &reqwest::Client,
 ) -> Result<String, human_errors::Error> {
     let params = [
         ("grant_type", "authorization_code"),
@@ -500,7 +503,7 @@ pub async fn exchange_code(
         ("client_secret", oidc.client_secret.as_str()),
     ];
 
-    let response: TokenResponse = reqwest::Client::new()
+    let response: TokenResponse = http_client
         .post(&discovery.token_endpoint)
         .form(&params)
         .send()

--- a/src/web/oauth.rs
+++ b/src/web/oauth.rs
@@ -110,6 +110,7 @@ async fn oauth_callback<S: Services + Send + Sync + 'static>(
                     .handle_callback(
                         format!("{base_url}/oauth/{provider}/callback"),
                         code.clone(),
+                        &services.http_client(),
                     )
                     .await
                 {
@@ -215,6 +216,7 @@ impl OAuth2Config {
         &self,
         redirect_url: impl ToString,
         code: impl ToString,
+        http_client: &reqwest::Client,
     ) -> Result<OAuth2RefreshToken, human_errors::Error> {
         let client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(self.client_id.clone()))
             .set_client_secret(oauth2::ClientSecret::new(self.client_secret.clone()))
@@ -228,7 +230,7 @@ impl OAuth2Config {
 
         let token_result = client
             .exchange_code(oauth2::AuthorizationCode::new(code.to_string()))
-            .request_async(&reqwest::Client::new())
+            .request_async(http_client)
             .await
             .wrap_user_err(
                 format!("Failed to obtain OAuth access token for {}.", &self.name),
@@ -257,6 +259,7 @@ impl OAuth2Config {
     pub async fn get_access_token(
         &self,
         token_entry: &OAuth2RefreshToken,
+        http_client: &reqwest::Client,
     ) -> Result<OAuth2RefreshToken, human_errors::Error> {
         let client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(self.client_id.clone()))
             .set_client_secret(oauth2::ClientSecret::new(self.client_secret.clone()))
@@ -267,13 +270,11 @@ impl OAuth2Config {
             return Ok(token_entry.clone());
         }
 
-        let http_client = reqwest::Client::new();
-
         let token_result = client
             .exchange_refresh_token(&oauth2::RefreshToken::new(
                 token_entry.refresh_token.clone(),
             ))
-            .request_async(&http_client)
+            .request_async(http_client)
             .await
             .wrap_user_err(
                 format!("Failed to refresh OAuth access token for {}.", &self.name),

--- a/src/web/oidc.rs
+++ b/src/web/oidc.rs
@@ -137,7 +137,7 @@ pub async fn oidc_callback<S: Services + Send + Sync + 'static>(
     };
 
     let redirect_uri = format!("{base}/admin{CALLBACK_PATH_SUFFIX}");
-    let token = match exchange_code(&oidc, &discovery, code, &redirect_uri).await {
+    let token = match exchange_code(&oidc, &discovery, code, &redirect_uri, &services.http_client()).await {
         Ok(token) => token,
         Err(e) => {
             error!("OIDC token exchange failed: {e}");


### PR DESCRIPTION
Expose a pooled reqwest::Client with the SierraSoftworks/automate user agent via Services::http_client() and migrate the RSS, GitHub releases, GitHub notifications, calendar, and Spotify collectors/publishers as well as the OAuth and OIDC flows to use it instead of constructing their own clients or calling reqwest::get.