### PR TITLE
Add YNAB stock-value synchronisation workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: cargo install grcov
         uses: SierraSoftworks/setup-grcov@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -50,7 +50,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.1",
- "sha1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -148,10 +148,10 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
+ "cookie 0.16.2",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -190,6 +190,17 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ahash"
@@ -227,6 +238,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -294,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +346,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -369,6 +392,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rstest",
  "rusqlite",
+ "rust-ynab",
  "scraper",
  "serde",
  "serde_json",
@@ -383,6 +407,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "wiremock",
+ "yfinance-rs",
 ]
 
 [[package]]
@@ -483,6 +508,21 @@ name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -500,6 +540,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -530,6 +594,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,7 +636,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d4f7ea9ab08310fba58c0010e3c203aaa2b6464f1d4886d36855d99b6b6036"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "chrono",
  "chrono-tz",
  "hashify",
@@ -619,6 +705,7 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+ "serde",
 ]
 
 [[package]]
@@ -652,7 +739,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -718,6 +805,8 @@ checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
+ "flate2",
+ "memchr",
 ]
 
 [[package]]
@@ -762,6 +851,35 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie 0.18.1",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -895,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -928,7 +1046,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -939,8 +1057,28 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -997,7 +1135,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1007,7 +1145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1029,7 +1167,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1063,7 +1201,16 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1200,6 +1347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1381,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1311,7 +1470,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1416,6 +1575,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,11 +1637,37 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1477,7 +1685,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1970,6 +2178,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "isin"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bcf2544150282ebe712b4615813c1986bb014564928b1c4a4a567402d6bf02"
+
+[[package]]
+name = "iso_country"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20633e788d3948ea7336861fdb09ec247f5dae4267e8f0743fa97de26c28624d"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "iso_currency"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed4b3f0921193400b1df556228bfd917c57c7fa38bda904d552653c5c3b641b"
+dependencies = [
+ "iso_country",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,7 +2256,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2041,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2130,6 +2364,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -2268,6 +2508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2535,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2397,7 +2649,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2522,6 +2774,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "paft"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3995b75c63ac2c9291e97b958ef52e42af3b0a48589b8139d8176535cb17b8"
+dependencies = [
+ "iso_currency",
+ "paft-aggregates",
+ "paft-core",
+ "paft-decimal",
+ "paft-domain",
+ "paft-fundamentals",
+ "paft-market",
+ "paft-money",
+ "paft-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paft-aggregates"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56199dd75535a86e54086d9cebc96573ce089f3200509195b5d1baa59746103"
+dependencies = [
+ "chrono",
+ "paft-domain",
+ "paft-money",
+ "serde",
+]
+
+[[package]]
+name = "paft-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec022386ad00b0934e1de3d0658ad77ad88da78e25a8c1504a7d469e890958b"
+dependencies = [
+ "chrono",
+ "paft-utils",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paft-decimal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b83a121e6f3c0c041b833fb448e7d31c5edecb6d2758cea2246e88c9f3cba42"
+dependencies = [
+ "rust_decimal",
+]
+
+[[package]]
+name = "paft-domain"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020e7c645f64a8eaf5553443030577c40bf75c4d36be57a991a806c92baa4ea8"
+dependencies = [
+ "chrono",
+ "isin",
+ "paft-core",
+ "paft-utils",
+ "serde",
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paft-fundamentals"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5562b5687159518fa7066c00faaf805d160e65a6c0189367844bb020d527cd0f"
+dependencies = [
+ "chrono",
+ "paft-core",
+ "paft-decimal",
+ "paft-domain",
+ "paft-money",
+ "paft-utils",
+ "serde",
+]
+
+[[package]]
+name = "paft-market"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95acda9df87959a08dbce715ada0008adb80dd9e8d28b8b27f7b48efd6381b44"
+dependencies = [
+ "bitflags 2.12.1",
+ "chrono",
+ "chrono-tz",
+ "paft-decimal",
+ "paft-domain",
+ "paft-money",
+ "paft-utils",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paft-money"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b5b85391fd26062d6d27f7d12911dbfc74c17ff7e99a95fd87aad81230f582"
+dependencies = [
+ "iso_currency",
+ "paft-decimal",
+ "paft-utils",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paft-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dcdd035fcd9e6a264fd37b128010e783bfd33531580a0a3fe6d66d16570033e"
+dependencies = [
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2938,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -2636,7 +3020,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2649,7 +3033,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2696,7 +3080,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2754,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2801,6 +3185,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,7 +3213,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2820,6 +3223,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2908,6 +3362,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_fmt"
@@ -3001,6 +3461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.12.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,6 +3576,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie 0.18.1",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "h2 0.4.14",
@@ -3142,6 +3622,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3154,6 +3635,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3162,6 +3644,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
@@ -3189,6 +3672,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,7 +3725,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3230,6 +3742,40 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ynab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2e07c7c202c04d48fa39f4b167d54d430dbc7174327124aff8d2f5bd2203c3"
+dependencies = [
+ "chrono",
+ "governor",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3398,6 +3944,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,7 +4104,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3598,6 +4159,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3745,6 +4317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,6 +4344,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -3819,7 +4410,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3827,6 +4418,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3862,7 +4464,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3915,6 +4517,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3976,7 +4584,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3987,7 +4595,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4093,7 +4701,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4136,6 +4744,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4330,7 +4954,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4340,7 +4964,7 @@ source = "git+https://github.com/SierraSoftworks/tracing.git#1440cc1e479e7c18b57
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4438,6 +5062,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.1",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -4653,6 +5296,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -4686,7 +5330,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4784,6 +5428,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,6 +5451,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4813,7 +5479,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4824,7 +5490,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5171,7 +5837,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5187,7 +5853,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5236,6 +5902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xml5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,6 +5918,30 @@ checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "yfinance-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b05cd5818c3ad752ac05c351e46d209e2ee6bc9a47605c2a74c4b52c1051727"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "chrono-tz",
+ "futures",
+ "futures-util",
+ "paft",
+ "prost",
+ "prost-build",
+ "reqwest 0.12.28",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
 ]
 
 [[package]]
@@ -5264,7 +5963,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5285,7 +5984,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5305,7 +6004,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5326,7 +6025,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5359,7 +6058,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ common manual tasks and use Todoist to request human involvement
 when necessary.
 
 It facilitates things like calendar sync, RSS syndication, and
-the automatic management of GitHub notifications; as well as
-handling webhooks from services like Tailscale and Honeycomb.
+the automatic management of GitHub notifications, as well as
+keeping YNAB stock accounts up to date with live market prices;
+it also handles webhooks from services like Tailscale and Honeycomb.
 
 ## Configuration
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -28,6 +28,7 @@ openssl-sys = { version = "0.9.116", features = ["vendored"], optional = true }
 regex = "1.12.3"
 reqwest = { version = "0.12.27", features = ["rustls-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }
+rust-ynab = "0.4"
 scraper = "0.27.0"
 serde = { version = "1.0.219", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.150", features = ["alloc"] }
@@ -43,9 +44,10 @@ tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batterie
   "opentelemetry",
 ] }
 urlencoding = "2.1.3"
-uuid = "1.23.2"
+uuid = { version = "1.23.2", features = ["serde", "v4"] }
 futures = "0.3.32"
 oauth2 = "5.0.0"
+yfinance-rs = "0.8"
 
 [dev-dependencies]
 base64 = "0.22"

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -107,6 +107,9 @@ pub struct ConnectionConfigs {
 
     #[serde(default)]
     pub github: GitHubConfig,
+
+    #[serde(default)]
+    pub ynab: YnabConfig,
 }
 
 #[derive(Clone, Deserialize, Default)]
@@ -221,10 +224,19 @@ pub struct WorkflowConfigs {
     pub youtube: Vec<CronJobConfig<YouTubeWorkflow>>,
     #[serde(default)]
     pub xkcd: Vec<CronJobConfig<XkcdWorkflow>>,
+    #[serde(default)]
+    pub ynab_stocks: Vec<CronJobConfig<YnabStocksWorkflow>>,
 }
 
 #[derive(Default, Clone, Deserialize)]
 pub struct GitHubConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}
+
+#[derive(Default, Clone, Deserialize)]
+pub struct YnabConfig {
+    /// The YNAB Personal Access Token used to authenticate with the YNAB API.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 }

--- a/agent/src/jobs/mod.rs
+++ b/agent/src/jobs/mod.rs
@@ -7,6 +7,7 @@ mod rss;
 mod spotify_yearly_playlist;
 mod todoist_cleanup;
 mod xkcd;
+mod ynab_stocks;
 mod youtube;
 
 pub use calendar::CalendarWorkflow;
@@ -16,4 +17,5 @@ pub use github_notifications_cleanup::GitHubNotificationsCleanupWorkflow;
 pub use github_releases::GitHubReleasesWorkflow;
 pub use rss::RssWorkflow;
 pub use xkcd::XkcdWorkflow;
+pub use ynab_stocks::YnabStocksWorkflow;
 pub use youtube::YouTubeWorkflow;

--- a/agent/src/jobs/ynab_stocks.rs
+++ b/agent/src/jobs/ynab_stocks.rs
@@ -1,0 +1,573 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use rust_ynab::{Account, ClearedStatus, Client, NewTransaction, PlanId};
+use uuid::Uuid;
+use yfinance_rs::{Ticker, YfClient};
+
+use crate::parsers::parse_key_value_pairs;
+use crate::prelude::*;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct YnabStocksConfig {
+    /// The YNAB budget (plan) whose stock accounts should be synchronised.
+    pub budget: Uuid,
+}
+
+impl Display for YnabStocksConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ynab-stocks/{}", self.budget)
+    }
+}
+
+#[derive(Clone)]
+pub struct YnabStocksWorkflow;
+
+crate::register_job!(YnabStocksWorkflow);
+
+/// The persisted synchronisation state for a single budget. The account mirror
+/// allows us to fetch only the changes since our last run by supplying the
+/// stored server knowledge token to YNAB.
+#[derive(Clone, Serialize, Deserialize, Default)]
+struct StocksState {
+    #[serde(default)]
+    server_knowledge: Option<i64>,
+    #[serde(default)]
+    accounts: HashMap<Uuid, Account>,
+}
+
+/// A cached ticker quote, expressed in the instrument's native currency.
+#[derive(Clone, Serialize, Deserialize)]
+struct CachedQuote {
+    price: f64,
+    currency: String,
+}
+
+/// The parsed `/automate:stock` directive from an account note.
+#[derive(Debug, PartialEq)]
+struct StockSpec {
+    /// The (ticker symbol, quantity held) pairs.
+    holdings: Vec<(String, f64)>,
+    /// The raw cost-basis specification (e.g. `USD5000` or `5000`), if provided.
+    cost_basis: Option<String>,
+    /// The capital gains tax rate, expressed as a fraction (e.g. `0.4` for 40%).
+    cgt_rate: f64,
+    /// The payee name to use for adjustment transactions, if overridden.
+    payee_name: Option<String>,
+}
+
+/// The valuation of a single holding, used both for the net-value calculation
+/// and for building a human-readable transaction memo.
+struct StockValue {
+    symbol: String,
+    native_currency: String,
+    native_price: f64,
+    native_value: f64,
+    /// The value of the holding converted into the budget's currency.
+    value: f64,
+}
+
+impl Job for YnabStocksWorkflow {
+    type JobType = YnabStocksConfig;
+
+    fn partition() -> &'static str {
+        "ynab/stocks"
+    }
+
+    #[instrument("workflow.ynab_stocks.setup", skip(self, services), err(Display))]
+    async fn setup(
+        &self,
+        services: impl Services + Send + Sync + 'static,
+    ) -> Result<(), human_errors::Error> {
+        let config = services.config();
+        CronJob::schedule(&config.workflows.ynab_stocks, services).await
+    }
+
+    #[instrument("workflow.ynab_stocks.handle", skip(self, ctx, job), fields(job = %job))]
+    async fn handle(
+        &self,
+        ctx: JobContext<impl Services + Send + Sync + 'static>,
+        job: &Self::JobType,
+    ) -> Result<(), human_errors::Error> {
+        let services = ctx.services();
+        let config = services.config();
+
+        let api_key = config.connections.ynab.api_key.as_deref().ok_or_else(|| {
+            human_errors::user(
+                "No YNAB API key has been configured.",
+                &[
+                    "Set `connections.ynab.api_key` in your configuration file (for example via the YNAB_API_KEY environment variable).",
+                    "Create a Personal Access Token from your YNAB account settings.",
+                ],
+            )
+        })?;
+
+        let client = Client::new(api_key).wrap_user_err(
+            "We could not initialise the YNAB API client.",
+            &["Check that your YNAB Personal Access Token is valid."],
+        )?;
+
+        let yf = YfClient::default();
+
+        let budget = job.budget;
+        let plan = PlanId::Id(budget);
+
+        let kv = services.kv();
+        let mut state: StocksState = kv
+            .get("ynab/stocks/state", budget.to_string())
+            .await?
+            .unwrap_or_default();
+
+        // Fetch only the accounts that have changed since our last run by
+        // supplying the stored server knowledge token to YNAB.
+        let request = client.get_accounts(plan);
+        let request = match state.server_knowledge {
+            Some(sk) => request.with_server_knowledge(sk),
+            None => request,
+        };
+        let (changed, new_knowledge) = request.send().await.wrap_system_err(
+            format!("Failed to fetch the accounts for YNAB budget '{budget}'."),
+            &[
+                "Check that the budget ID is correct.",
+                "Check that your YNAB API key has access to this budget.",
+            ],
+        )?;
+
+        for account in changed {
+            if account.deleted {
+                state.accounts.remove(&account.id);
+            } else {
+                state.accounts.insert(account.id, account);
+            }
+        }
+        state.server_knowledge = Some(new_knowledge);
+        kv.set("ynab/stocks/state", budget.to_string(), state.clone())
+            .await?;
+
+        let settings = client.get_plan_settings(plan).await.wrap_system_err(
+            format!("Failed to fetch the settings for YNAB budget '{budget}'."),
+            &["Check that the budget ID is correct."],
+        )?;
+        let budget_currency = settings.currency_format.iso_code;
+
+        for account in state.accounts.values() {
+            if account.closed {
+                continue;
+            }
+
+            let Some(note) = account.note.as_deref() else {
+                continue;
+            };
+            let Some(spec) = parse_stock_command(note) else {
+                continue;
+            };
+
+            // Value each holding in the budget's currency.
+            let mut values = Vec::with_capacity(spec.holdings.len());
+            for (symbol, quantity) in &spec.holdings {
+                let quote = fetch_quote(&yf, services, symbol).await?;
+                let rate = fetch_rate(&yf, services, &quote.currency, &budget_currency).await?;
+                let native_value = quantity * quote.price;
+                values.push(StockValue {
+                    symbol: symbol.clone(),
+                    native_currency: quote.currency,
+                    native_price: quote.price,
+                    native_value,
+                    value: native_value * rate,
+                });
+            }
+
+            if values.is_empty() {
+                continue;
+            }
+
+            let gross: f64 = values.iter().map(|v| v.value).sum();
+
+            // Convert the cost basis (which may be quoted in any currency) into
+            // the budget's currency before applying the CGT deduction.
+            let cost_basis = match spec.cost_basis.as_deref() {
+                Some(raw) => match parse_currency_value(raw) {
+                    Some((Some(ccy), amount)) => {
+                        let rate = fetch_rate(&yf, services, &ccy, &budget_currency).await?;
+                        amount * rate
+                    }
+                    Some((None, amount)) => amount,
+                    None => 0.0,
+                },
+                None => 0.0,
+            };
+
+            let net = net_value(gross, cost_basis, spec.cgt_rate);
+            let shift = compute_shift(net, account.balance);
+
+            // 1000 milliunits == 1 unit of the budget's currency, so we ignore
+            // sub-unit fluctuations to avoid spamming the account with tiny
+            // corrections.
+            if shift.abs() <= 1000 {
+                tracing::info!(
+                    account = %account.name,
+                    shift,
+                    "Skipping stock adjustment because the change is below the minimum threshold."
+                );
+                continue;
+            }
+
+            let payee_name = spec
+                .payee_name
+                .clone()
+                .unwrap_or_else(|| "Stock Market".to_string());
+
+            client
+                .create_transaction(
+                    plan,
+                    NewTransaction {
+                        account_id: account.id,
+                        date: chrono::Utc::now().date_naive(),
+                        amount: shift,
+                        payee_id: None,
+                        payee_name: Some(payee_name),
+                        category_id: None,
+                        memo: Some(build_memo(&values)),
+                        cleared: Some(ClearedStatus::Cleared),
+                        approved: Some(true),
+                        flag_color: None,
+                        import_id: None,
+                        subtransactions: None,
+                    },
+                )
+                .await
+                .wrap_system_err(
+                    format!(
+                        "Failed to record a stock value adjustment for account '{}'.",
+                        account.name
+                    ),
+                    &["Check that your YNAB API key has write access to this budget."],
+                )?;
+
+            tracing::info!(
+                account = %account.name,
+                shift,
+                "Recorded a stock value adjustment transaction."
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Fetches a ticker quote, caching the result for 12 hours.
+async fn fetch_quote(
+    yf: &YfClient,
+    services: &(impl Services + Send + Sync + 'static),
+    symbol: &str,
+) -> Result<CachedQuote, human_errors::Error> {
+    let yf = yf.clone();
+    let symbol_owned = symbol.to_string();
+
+    services
+        .cache()
+        .cached(
+            "ynab/stocks/quotes",
+            symbol.to_string(),
+            move || {
+                Box::pin(async move {
+                    let ticker = Ticker::new(&yf, symbol_owned.as_str());
+                    let quote = ticker.quote().await.wrap_system_err(
+                        format!(
+                            "Failed to fetch a stock quote for '{symbol_owned}' from Yahoo Finance."
+                        ),
+                        &["Check that the ticker symbol is valid and recognised by Yahoo Finance."],
+                    )?;
+
+                    let price = quote.price.ok_or_else(|| {
+                        human_errors::system(
+                            format!("Yahoo Finance did not return a price for '{symbol_owned}'."),
+                            &["The market may be closed or the symbol may be delisted."],
+                        )
+                    })?;
+
+                    let amount = price.amount().to_string().parse::<f64>().wrap_system_err(
+                        format!("Failed to parse the price returned for '{symbol_owned}'."),
+                        &["Report this issue to the development team on GitHub."],
+                    )?;
+
+                    Ok(CachedQuote {
+                        price: amount,
+                        currency: price.currency().code().to_string(),
+                    })
+                })
+            },
+            chrono::Duration::hours(12),
+        )
+        .await
+}
+
+/// Fetches the exchange rate from `from` to `to`, caching the result for
+/// 12 hours. Returns `1.0` when the currencies match.
+async fn fetch_rate(
+    yf: &YfClient,
+    services: &(impl Services + Send + Sync + 'static),
+    from: &str,
+    to: &str,
+) -> Result<f64, human_errors::Error> {
+    let from = from.to_uppercase();
+    let to = to.to_uppercase();
+
+    if from == to {
+        return Ok(1.0);
+    }
+
+    let yf = yf.clone();
+    let key = format!("{from}:{to}");
+    let pair = format!("{from}{to}=X");
+
+    services
+        .cache()
+        .cached(
+            "ynab/stocks/fx",
+            key,
+            move || {
+                Box::pin(async move {
+                    let ticker = Ticker::new(&yf, pair.as_str());
+                    let quote = ticker.quote().await.wrap_system_err(
+                        format!("Failed to fetch the exchange rate '{pair}' from Yahoo Finance."),
+                        &["Check that both currency codes are valid ISO currency codes."],
+                    )?;
+
+                    let price = quote.price.ok_or_else(|| {
+                        human_errors::system(
+                            format!("Yahoo Finance did not return an exchange rate for '{pair}'."),
+                            &["The currency pair may not be supported by Yahoo Finance."],
+                        )
+                    })?;
+
+                    let rate = price.amount().to_string().parse::<f64>().wrap_system_err(
+                        format!("Failed to parse the exchange rate returned for '{pair}'."),
+                        &["Report this issue to the development team on GitHub."],
+                    )?;
+
+                    Ok(rate)
+                })
+            },
+            chrono::Duration::hours(12),
+        )
+        .await
+}
+
+/// Computes the net portfolio value after applying a capital gains tax
+/// deduction. The deduction is `max((gross - cost_basis) * cgt_rate, 0)`,
+/// mirroring the behaviour of the original automation.
+fn net_value(gross: f64, cost_basis: f64, cgt_rate: f64) -> f64 {
+    let cgt = ((gross - cost_basis) * cgt_rate).max(0.0);
+    gross - cgt
+}
+
+/// Computes the adjustment (in milliunits) required to bring an account with
+/// the given balance up to the target net value.
+fn compute_shift(net: f64, current_balance: i64) -> i64 {
+    let net_milliunits = (net * 1000.0).floor() as i64;
+    net_milliunits - current_balance
+}
+
+/// Builds a human-readable memo summarising the valued holdings, truncated to
+/// fit within YNAB's memo length limit.
+fn build_memo(values: &[StockValue]) -> String {
+    let memo = values
+        .iter()
+        .map(|v| {
+            format!(
+                "{}: {} {:.2} @ {:.2}",
+                v.symbol, v.native_currency, v.native_value, v.native_price
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    truncate_memo(&memo)
+}
+
+/// Truncates a memo to 500 characters (YNAB's limit), appending an ellipsis
+/// when truncation occurs.
+fn truncate_memo(memo: &str) -> String {
+    if memo.chars().count() <= 500 {
+        return memo.to_string();
+    }
+
+    let truncated: String = memo.chars().take(500 - 1).collect();
+    format!("{truncated}…")
+}
+
+/// Parses a `/automate:stock` directive from an account note. Returns `None`
+/// when the note does not contain the directive or specifies no holdings.
+fn parse_stock_command(note: &str) -> Option<StockSpec> {
+    let start = note.find("/automate:stock")?;
+    let rest = &note[start + "/automate:stock".len()..];
+    // The directive occupies a single line.
+    let line = rest.lines().next().unwrap_or("");
+
+    let mut holdings = Vec::new();
+    let mut cost_basis = None;
+    let mut cgt_rate = 0.0;
+    let mut payee_name = None;
+
+    for (key, value) in parse_key_value_pairs(line) {
+        match key.as_str() {
+            "cost_basis" => cost_basis = Some(value),
+            "cgt_rate" => {
+                cgt_rate = value
+                    .trim_end_matches('%')
+                    .trim()
+                    .parse::<f64>()
+                    .unwrap_or(0.0)
+                    / 100.0;
+            }
+            "payee_name" => payee_name = Some(value),
+            symbol => {
+                if let Ok(quantity) = value.parse::<f64>() {
+                    holdings.push((symbol.to_string(), quantity));
+                }
+            }
+        }
+    }
+
+    if holdings.is_empty() {
+        return None;
+    }
+
+    Some(StockSpec {
+        holdings,
+        cost_basis,
+        cgt_rate,
+        payee_name,
+    })
+}
+
+/// Parses a currency-qualified amount such as `USD5000` or `5000`, returning
+/// the optional currency code and the numeric amount.
+fn parse_currency_value(input: &str) -> Option<(Option<String>, f64)> {
+    let input = input.trim();
+    let split = input.find(|c: char| c.is_ascii_digit() || c == '.')?;
+    let (currency, amount) = input.split_at(split);
+
+    let amount = amount.parse::<f64>().ok()?;
+    let currency = if currency.is_empty() {
+        None
+    } else {
+        Some(currency.to_string())
+    };
+
+    Some((currency, amount))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn parses_full_stock_command() {
+        let note = "Some preamble\n/automate:stock MSFT=100 AAPL=50 cost_basis=USD5000 cgt_rate=40% payee_name=\"My Broker\"\nTrailing notes";
+        let spec = parse_stock_command(note).expect("directive should parse");
+
+        assert_eq!(
+            spec.holdings,
+            vec![("MSFT".to_string(), 100.0), ("AAPL".to_string(), 50.0)]
+        );
+        assert_eq!(spec.cost_basis.as_deref(), Some("USD5000"));
+        assert!((spec.cgt_rate - 0.4).abs() < f64::EPSILON);
+        assert_eq!(spec.payee_name.as_deref(), Some("My Broker"));
+    }
+
+    #[test]
+    fn parses_minimal_stock_command() {
+        let spec = parse_stock_command("/automate:stock GOOG=10").expect("directive should parse");
+
+        assert_eq!(spec.holdings, vec![("GOOG".to_string(), 10.0)]);
+        assert_eq!(spec.cost_basis, None);
+        assert_eq!(spec.cgt_rate, 0.0);
+        assert_eq!(spec.payee_name, None);
+    }
+
+    #[test]
+    fn parses_fractional_quantities_and_dotted_symbols() {
+        let spec =
+            parse_stock_command("/automate:stock VOD.L=12.5 BRK.B=2").expect("directive parses");
+
+        assert_eq!(
+            spec.holdings,
+            vec![("VOD.L".to_string(), 12.5), ("BRK.B".to_string(), 2.0)]
+        );
+    }
+
+    #[test]
+    fn returns_none_without_directive() {
+        assert!(parse_stock_command("Just a regular note").is_none());
+    }
+
+    #[test]
+    fn returns_none_without_holdings() {
+        assert!(parse_stock_command("/automate:stock cost_basis=USD5000").is_none());
+    }
+
+    #[rstest]
+    #[case("USD5000", Some("USD"), 5000.0)]
+    #[case("5000", None, 5000.0)]
+    #[case("EUR1234.56", Some("EUR"), 1234.56)]
+    #[case(" GBP10 ", Some("GBP"), 10.0)]
+    fn parses_currency_values(
+        #[case] input: &str,
+        #[case] expected_currency: Option<&str>,
+        #[case] expected_amount: f64,
+    ) {
+        let (currency, amount) = parse_currency_value(input).expect("value should parse");
+        assert_eq!(currency.as_deref(), expected_currency);
+        assert!((amount - expected_amount).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn rejects_non_numeric_currency_values() {
+        assert!(parse_currency_value("USD").is_none());
+        assert!(parse_currency_value("").is_none());
+    }
+
+    #[test]
+    fn net_value_applies_capital_gains_deduction() {
+        // gross 10000, cost basis 5000, 40% CGT on the 5000 gain => 2000 deduction.
+        let net = net_value(10_000.0, 5_000.0, 0.4);
+        assert!((net - 8_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn net_value_never_applies_negative_deduction() {
+        // gross below cost basis => no tax owed, net equals gross.
+        let net = net_value(4_000.0, 5_000.0, 0.4);
+        assert!((net - 4_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn net_value_without_cost_basis_taxes_full_gross() {
+        let net = net_value(10_000.0, 0.0, 0.25);
+        assert!((net - 7_500.0).abs() < f64::EPSILON);
+    }
+
+    #[rstest]
+    #[case(100.0, 50_000, 50_000)]
+    #[case(100.0, 150_000, -50_000)]
+    #[case(100.0, 100_000, 0)]
+    fn computes_shift_in_milliunits(#[case] net: f64, #[case] balance: i64, #[case] expected: i64) {
+        assert_eq!(compute_shift(net, balance), expected);
+    }
+
+    #[test]
+    fn truncate_memo_leaves_short_memos_untouched() {
+        assert_eq!(truncate_memo("short"), "short");
+    }
+
+    #[test]
+    fn truncate_memo_truncates_long_memos() {
+        let memo = "x".repeat(500 + 10);
+        let truncated = truncate_memo(&memo);
+        assert_eq!(truncated.chars().count(), 500);
+        assert!(truncated.ends_with('…'));
+    }
+}

--- a/agent/src/jobs/ynab_stocks.rs
+++ b/agent/src/jobs/ynab_stocks.rs
@@ -464,14 +464,21 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    /// Sorts holdings by symbol so assertions don't depend on the
+    /// non-deterministic ordering produced by the underlying hash map.
+    fn sorted_holdings(mut holdings: Vec<(String, f64)>) -> Vec<(String, f64)> {
+        holdings.sort_by(|a, b| a.0.cmp(&b.0));
+        holdings
+    }
+
     #[test]
     fn parses_full_stock_command() {
         let note = "Some preamble\n/automate:stock MSFT=100 AAPL=50 cost_basis=USD5000 cgt_rate=40% payee_name=\"My Broker\"\nTrailing notes";
         let spec = parse_stock_command(note).expect("directive should parse");
 
         assert_eq!(
-            spec.holdings,
-            vec![("MSFT".to_string(), 100.0), ("AAPL".to_string(), 50.0)]
+            sorted_holdings(spec.holdings),
+            vec![("AAPL".to_string(), 50.0), ("MSFT".to_string(), 100.0)]
         );
         assert_eq!(spec.cost_basis.as_deref(), Some("USD5000"));
         assert!((spec.cgt_rate - 0.4).abs() < f64::EPSILON);
@@ -494,8 +501,8 @@ mod tests {
             parse_stock_command("/automate:stock VOD.L=12.5 BRK.B=2").expect("directive parses");
 
         assert_eq!(
-            spec.holdings,
-            vec![("VOD.L".to_string(), 12.5), ("BRK.B".to_string(), 2.0)]
+            sorted_holdings(spec.holdings),
+            vec![("BRK.B".to_string(), 2.0), ("VOD.L".to_string(), 12.5)]
         );
     }
 

--- a/agent/src/parsers/key_value_pair.rs
+++ b/agent/src/parsers/key_value_pair.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+/// Parses a string of whitespace-separated `key=value` pairs into a map.
+///
+/// Values may be wrapped in double quotes to allow them to contain whitespace,
+/// for example `name="hello world"`. The surrounding quotes are stripped from
+/// the resulting value. Tokens that do not contain an `=` are ignored, as are
+/// pairs with an empty key. When a key appears more than once the last value
+/// wins.
+///
+/// # Example
+///
+/// ```
+/// use automate::parsers::parse_key_value_pairs;
+///
+/// let pairs = parse_key_value_pairs("MSFT=100 payee_name=\"Stock Market\"");
+/// assert_eq!(pairs.get("MSFT").map(String::as_str), Some("100"));
+/// assert_eq!(pairs.get("payee_name").map(String::as_str), Some("Stock Market"));
+/// ```
+pub fn parse_key_value_pairs(input: &str) -> HashMap<String, String> {
+    let mut pairs = HashMap::new();
+
+    for token in tokenize(input) {
+        let Some((key, value)) = token.split_once('=') else {
+            continue;
+        };
+
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+
+        pairs.insert(key.to_string(), unquote(value.trim()).to_string());
+    }
+
+    pairs
+}
+
+/// Splits a string into whitespace-separated tokens, treating text within
+/// double quotes as a single token (so quoted values may contain spaces).
+fn tokenize(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for c in input.chars() {
+        match c {
+            '"' => {
+                in_quotes = !in_quotes;
+                current.push(c);
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(c),
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+/// Strips a single pair of surrounding double quotes from a value, if present.
+fn unquote(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .unwrap_or(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_pairs() {
+        let pairs = parse_key_value_pairs("a=1 b=2 c=3");
+        assert_eq!(pairs.get("a").map(String::as_str), Some("1"));
+        assert_eq!(pairs.get("b").map(String::as_str), Some("2"));
+        assert_eq!(pairs.get("c").map(String::as_str), Some("3"));
+    }
+
+    #[test]
+    fn respects_quoted_values() {
+        let pairs = parse_key_value_pairs("a=1 name=\"hello world\" b=2");
+        assert_eq!(pairs.get("a").map(String::as_str), Some("1"));
+        assert_eq!(pairs.get("name").map(String::as_str), Some("hello world"));
+        assert_eq!(pairs.get("b").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn ignores_tokens_without_equals() {
+        let pairs = parse_key_value_pairs("standalone a=1");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs.get("a").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn ignores_empty_keys() {
+        let pairs = parse_key_value_pairs("=value a=1");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs.get("a").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn last_value_wins_for_duplicate_keys() {
+        let pairs = parse_key_value_pairs("a=1 a=2");
+        assert_eq!(pairs.get("a").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn returns_empty_for_blank_input() {
+        assert!(parse_key_value_pairs("").is_empty());
+        assert!(parse_key_value_pairs("   ").is_empty());
+    }
+}

--- a/agent/src/parsers/mod.rs
+++ b/agent/src/parsers/mod.rs
@@ -1,7 +1,9 @@
 mod calendar;
 mod html;
 mod interpolation;
+mod key_value_pair;
 
 pub use calendar::{Calendar, CalendarEvent};
 pub use html::html_to_markdown;
 pub use interpolation::interpolate;
+pub use key_value_pair::parse_key_value_pairs;

--- a/agent/src/publishers/spotify.rs
+++ b/agent/src/publishers/spotify.rs
@@ -188,7 +188,9 @@ impl SpotifyClient {
         services: &(impl Services + Send + Sync + 'static),
     ) -> Result<OAuth2RefreshToken, human_errors::Error> {
         let config = services.config().get_oauth2("spotify")?;
-        config.get_access_token(token, &services.http_client()).await
+        config
+            .get_access_token(token, &services.http_client())
+            .await
     }
 }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,6 +4,10 @@ api_key = "${{ env.GITHUB_API_KEY }}"
 [connections.todoist]
 api_key = "${{ env.TODOIST_API_KEY }}"
 
+[connections.ynab]
+# A YNAB Personal Access Token, created from your YNAB account settings.
+api_key = "${{ env.YNAB_API_KEY }}"
+
 [oauth2.spotify]
 name = "Spotify"
 jobs = ["workflow/spotify-yearly-playlist"]
@@ -127,3 +131,12 @@ filter = "title contains \"highlights | \" && !(title contains \"f2 \")"
 
 [[workflows.xkcd]]
 cron = "0 8 * * *"
+
+[[workflows.ynab_stocks]]
+# The YNAB budget (plan) ID whose stock accounts should be synchronised.
+budget = "00000000-0000-0000-0000-000000000000"
+cron = "0 */12 * * *"
+# Add `/automate:stock` to a YNAB account's note to opt it in, for example:
+#   /automate:stock MSFT=100 AAPL=50 cost_basis=USD5000 cgt_rate=40% payee_name="Stock Market"
+# Every `key=value` pair other than the reserved keys (cost_basis, cgt_rate,
+# payee_name) is treated as a ticker symbol and the quantity held.


### PR DESCRIPTION
## Summary

Migrates the functionality from [SierraSoftworks/ynab-automation](https://github.com/SierraSoftworks/ynab-automation) into this project as a new `ynab_stocks` cron workflow. It keeps a YNAB account's balance in sync with the live market value of the stocks held within it.

## How it works

- **Opt-in via account notes** — any YNAB account whose note contains an `/automate:stock` directive is synchronised, e.g.:
  ```
  /automate:stock MSFT=100 AAPL=50 cost_basis=USD5000 cgt_rate=40% payee_name="Stock Market"
  ```
  Every `key=value` pair other than the reserved keys (`cost_basis`, `cgt_rate`, `payee_name`) is treated as a ticker symbol and quantity held.
- **Market data** — ticker quotes and currency exchange rates are fetched with [`yfinance-rs`](https://docs.rs/yfinance-rs) and cached for up to 12 hours via `services.cache()`.
- **YNAB API** — accounts and transactions are accessed through [`rust-ynab`](https://docs.rs/rust-ynab) using `.with_server_knowledge()` for differential fetching, with the server knowledge token and account mirror persisted in the KV store.
- **Reconciliation** — the net portfolio value (after an optional cost-basis/CGT deduction, in budget currency) is compared against the account balance and reconciled by recording a cleared, approved adjustment transaction. Sub-unit changes (≤ 1000 milliunits) are skipped.
- **Secrets** — the YNAB Personal Access Token is configured via `[connections.ynab].api_key`, using the existing config interpolation support (e.g. `${{ env.YNAB_API_KEY }}`).

## Also included

- A reusable `parsers::parse_key_value_pairs` helper (quote-aware tokenizer producing a `HashMap<String, String>`).
- `config.example.toml` and README updates documenting the new connection and workflow.

## Testing

- New unit tests covering the note parser, currency-value parser, net-value/CGT math, shift-threshold logic, and memo truncation; plus tests for the new key-value parser.
- `cargo test`, `cargo clippy --all-targets --all-features`, and `cargo fmt --all --check` all pass (no new warnings).