### PR TITLE
fix(calendar): re-evaluate events when their content changes

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -8,7 +8,7 @@ automate-api = { path = "../api" }
 actix-web = "4.13.0"
 async-trait = "0.1.89"
 base64 = "0.22"
-calcard = "0.3.4"
+calcard = { version = "0.3.4", features = ["serde"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["cargo", "derive", "string"] }
 cron = "0.16.0"

--- a/agent/src/collectors/calendar.rs
+++ b/agent/src/collectors/calendar.rs
@@ -36,7 +36,7 @@ impl Collector for CalendarCollector {
         Ok(results
             .into_iter()
             .filter_map(|d| match d {
-                Diff::Added(_, item) => Some(item),
+                Diff::Added(_, item) | Diff::Modified(_, item) => Some(item),
                 _ => None,
             })
             .collect())
@@ -47,7 +47,9 @@ impl DifferentialCollector for CalendarCollector {
     type Identifier = CalendarEventIdentifier;
 
     fn partition(&self) -> &'static str {
-        "calendar/ics"
+        // v2 stores the full serialized event (not just its identifier) so that
+        // changes to fields such as the busy status retrigger evaluation.
+        "calendar/ics/v2"
     }
 
     fn key(&self) -> std::borrow::Cow<'static, str> {

--- a/agent/src/collectors/differential.rs
+++ b/agent/src/collectors/differential.rs
@@ -1,15 +1,22 @@
-use std::{borrow::Cow, collections::HashSet};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 use tracing_batteries::prelude::*;
 
 use crate::prelude::*;
 
 pub enum Diff<ID, V> {
     Added(ID, V),
+    Modified(ID, V),
     Removed(ID),
 }
 
 #[allow(dead_code)]
-pub trait DifferentialCollector: Collector {
+pub trait DifferentialCollector: Collector
+where
+    Self::Item: Serialize + DeserializeOwned + Clone + PartialEq + Send + 'static,
+{
     type Identifier: Eq + std::hash::Hash + Serialize + DeserializeOwned + Clone + Send + 'static;
 
     fn partition(&self) -> &'static str;
@@ -32,35 +39,41 @@ pub trait DifferentialCollector: Collector {
 
         let items = self.fetch(services).await?;
 
-        let old_identifiers: Vec<Self::Identifier> = services
+        let old_items: Vec<Self::Item> = services
             .kv()
             .get(partition, key.clone())
             .await?
             .unwrap_or_default();
 
+        let old_by_identifier: HashMap<Self::Identifier, Self::Item> = old_items
+            .into_iter()
+            .map(|item| (self.identifier(&item), item))
+            .collect();
+
         let mut new_identifiers = HashSet::new();
         let mut output = Vec::new();
 
-        for item in items.into_iter() {
-            let id = self.identifier(&item);
+        for item in items.iter() {
+            let id = self.identifier(item);
             new_identifiers.insert(id.clone());
 
-            if !old_identifiers.contains(&id) {
-                output.push(Diff::Added(id.clone(), item));
+            // Emit the item when it is newly seen or when its serialized content
+            // has changed, so downstream filters get a chance to re-evaluate it.
+            // Idempotency of the consuming job prevents duplicate side effects.
+            match old_by_identifier.get(&id) {
+                Some(previous) if previous == item => {}
+                Some(_) => output.push(Diff::Modified(id, item.clone())),
+                None => output.push(Diff::Added(id, item.clone())),
             }
         }
 
-        let removed_identifiers = old_identifiers
-            .into_iter()
-            .filter(|id| !new_identifiers.contains(id));
-
-        for id in removed_identifiers {
-            output.push(Diff::Removed(id));
+        for id in old_by_identifier.into_keys() {
+            if !new_identifiers.contains(&id) {
+                output.push(Diff::Removed(id));
+            }
         }
 
-        let new_identifiers: Vec<_> = new_identifiers.into_iter().collect();
-
-        services.kv().set(partition, key, new_identifiers).await?;
+        services.kv().set(partition, key, items).await?;
 
         Ok(output)
     }

--- a/agent/src/jobs/calendar.rs
+++ b/agent/src/jobs/calendar.rs
@@ -63,7 +63,9 @@ impl Job for CalendarWorkflow {
 
         for item in items.into_iter() {
             match item {
-                Diff::Added(id, item) if job.filter.matches(&item).unwrap_or_default() => {
+                Diff::Added(id, item) | Diff::Modified(id, item)
+                    if job.filter.matches(&item).unwrap_or_default() =>
+                {
                     info!(
                         "Calendar item '{}' matched filter, creating Todoist task",
                         item.summary
@@ -89,7 +91,7 @@ impl Job for CalendarWorkflow {
                     )
                     .await?;
                 }
-                Diff::Added(id, item) => {
+                Diff::Added(id, item) | Diff::Modified(id, item) => {
                     info!(
                         "Calendar item '{}' did not match filter, skipping Todoist creation",
                         item.summary

--- a/agent/src/parsers/calendar.rs
+++ b/agent/src/parsers/calendar.rs
@@ -159,6 +159,7 @@ impl FromStr for Calendar {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CalendarEvent {
     pub uid: String,
     pub summary: String,


### PR DESCRIPTION
Store the fully serialized CalendarEvent in the differential cache instead of just its identifier, and add a Diff::Modified variant so events whose fields (e.g. busy_status) change are re-emitted. The calendar workflow now relies on the Todoist idempotency key to avoid creating duplicates.