### PR TITLE
refactor(calendar): switch back to calendar/ics for collector state

### DIFF
--- a/agent/src/collectors/calendar.rs
+++ b/agent/src/collectors/calendar.rs
@@ -47,9 +47,7 @@ impl DifferentialCollector for CalendarCollector {
     type Identifier = CalendarEventIdentifier;
 
     fn partition(&self) -> &'static str {
-        // v2 stores the full serialized event (not just its identifier) so that
-        // changes to fields such as the busy status retrigger evaluation.
-        "calendar/ics/v2"
+        "calendar/ics"
     }
 
     fn key(&self) -> std::borrow::Cow<'static, str> {

--- a/agent/src/collectors/differential.rs
+++ b/agent/src/collectors/differential.rs
@@ -39,11 +39,23 @@ where
 
         let items = self.fetch(services).await?;
 
-        let old_items: Vec<Self::Item> = services
-            .kv()
-            .get(partition, key.clone())
-            .await?
-            .unwrap_or_default();
+        // Load the previously seen items. If the stored state can't be loaded or
+        // deserialized (for example because the storage format changed between
+        // versions), discard it and start from an empty baseline rather than
+        // blocking the collector. The consuming jobs are idempotent, so
+        // replaying items is safe.
+        let old_items: Vec<Self::Item> = match services.kv().get(partition, key.clone()).await {
+            Ok(old_items) => old_items.unwrap_or_default(),
+            Err(err) => {
+                warn!(
+                    collector.partition = partition,
+                    collector.key = %key,
+                    error = %err,
+                    "Failed to load previous collector state; discarding it and continuing from an empty baseline."
+                );
+                Vec::new()
+            }
+        };
 
         let old_by_identifier: HashMap<Self::Identifier, Self::Item> = old_items
             .into_iter()
@@ -76,5 +88,84 @@ where
         services.kv().set(partition, key, items).await?;
 
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::Services;
+
+    #[derive(Clone, PartialEq, Serialize, Deserialize)]
+    struct TestItem {
+        id: u32,
+    }
+
+    struct TestCollector {
+        items: Vec<TestItem>,
+    }
+
+    #[async_trait::async_trait]
+    impl Collector for TestCollector {
+        type Item = TestItem;
+
+        async fn list(
+            &self,
+            _services: &(impl Services + Send + Sync + 'static),
+        ) -> Result<Vec<Self::Item>, human_errors::Error> {
+            Ok(self.items.clone())
+        }
+    }
+
+    impl DifferentialCollector for TestCollector {
+        type Identifier = u32;
+
+        fn partition(&self) -> &'static str {
+            "test/differential"
+        }
+
+        fn key(&self) -> Cow<'static, str> {
+            Cow::Borrowed("key")
+        }
+
+        fn identifier(&self, item: &Self::Item) -> Self::Identifier {
+            item.id
+        }
+
+        async fn fetch(
+            &self,
+            _services: &impl Services,
+        ) -> Result<Vec<Self::Item>, human_errors::Error> {
+            Ok(self.items.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_diff_discards_unreadable_state() {
+        let services = crate::testing::mock_services().await.unwrap();
+
+        // Seed the store with a value that cannot be deserialized into the
+        // collector's `Vec<TestItem>` state, simulating a state-format change
+        // between versions (as happened with the calendar collector).
+        services
+            .kv()
+            .set("test/differential", "key", "not a list of items")
+            .await
+            .unwrap();
+
+        let collector = TestCollector {
+            items: vec![TestItem { id: 1 }, TestItem { id: 2 }],
+        };
+
+        // The unreadable state is discarded rather than blocking the collector,
+        // so every fetched item is treated as newly added.
+        let diffs = collector.diff(&services).await.unwrap();
+        assert_eq!(diffs.len(), 2);
+        assert!(diffs.iter().all(|d| matches!(d, Diff::Added(_, _))));
+
+        // The store now holds the fresh, well-formed state, so a subsequent run
+        // observes no changes.
+        let diffs = collector.diff(&services).await.unwrap();
+        assert!(diffs.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Reverts the calendar collector's state partition from `calendar/ics/v2` back to `calendar/ics`, and makes the differential collector resilient to unreadable stored state.

## Why

The move to `calendar/ics/v2` was introduced to migrate to a new state format (storing full serialized events instead of just identifiers). However, erasing the old calendar state is entirely safe because the calendar job is idempotent — there's no need to preserve a separate keyspace across the format change. Switching back to `calendar/ics` keeps the partition name stable.

To make that safe in general, `DifferentialCollector::diff` no longer fails when the previously stored state can't be loaded or deserialized (e.g. because the format changed between versions). Instead it logs a warning, discards the unreadable state, and continues from an empty baseline. The idempotent consuming jobs make replaying items harmless.

## Changes

- `agent/src/collectors/calendar.rs` — partition reverted to `calendar/ics` (the differential storage-format change and `Diff::Modified` handling are retained).
- `agent/src/collectors/differential.rs` — `diff()` treats a failed state load/deserialize as an empty baseline with a `warn!` log rather than erroring; added `test_diff_discards_unreadable_state` covering recovery and rewrite of well-formed state.

## Testing

- `cargo test -p automate` — all 323 tests pass
- `cargo fmt --all --check` — clean
- `cargo clippy -p automate --all-targets` — no new warnings in the changed files