### PR TITLE
feat: use ECB data for exchange rate conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "jsonwebtoken",
  "oauth2",
  "openssl-sys",
+ "quick-xml",
  "regex",
  "reqwest 0.12.28",
  "rstest",
@@ -3284,6 +3285,7 @@ checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "encoding_rs",
  "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -25,6 +25,7 @@ include_dir = "0.7.4"
 inventory = "0.3.22"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 openssl-sys = { version = "0.9.116", features = ["vendored"], optional = true }
+quick-xml = { version = "0.37.5", features = ["serialize"] }
 regex = "1.12.3"
 reqwest = { version = "0.12.27", features = ["rustls-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }

--- a/agent/src/collectors/ecb_rates.rs
+++ b/agent/src/collectors/ecb_rates.rs
@@ -1,0 +1,354 @@
+use crate::prelude::*;
+
+use super::Collector;
+
+/// The European Central Bank's daily reference exchange rate feed.
+///
+/// The feed expresses every rate relative to the Euro (i.e. the number of units
+/// of the foreign currency that one Euro buys), and is refreshed once per
+/// working day at around 16:00 CET.
+const DEFAULT_ECB_URL: &str = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml";
+
+/// A single exchange rate from the ECB feed, expressed as the number of units
+/// of `currency` that one Euro buys.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EcbExchangeRate {
+    pub currency: String,
+    pub rate: f64,
+}
+
+/// A collector which exposes the European Central Bank's daily reference
+/// exchange rates and converts amounts between any two of the supported
+/// currencies.
+///
+/// The parsed feed is cached for 24 hours (the ECB only publishes new rates
+/// once per working day), so repeated conversions within a run – and across
+/// runs on the same day – avoid re-fetching the upstream document.
+pub struct EcbRateCollector {
+    url: String,
+}
+
+impl Default for EcbRateCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EcbRateCollector {
+    pub fn new() -> Self {
+        Self {
+            url: DEFAULT_ECB_URL.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_with_url(url: impl ToString) -> Self {
+        Self {
+            url: url.to_string(),
+        }
+    }
+
+    /// Converts `value` from the `from` currency into the `to` currency using
+    /// the latest ECB reference rates.
+    ///
+    /// Both currency codes are matched case-insensitively, and `EUR` is always
+    /// supported (it is the base of every rate). When the two currencies are
+    /// the same the value is returned unchanged without fetching the feed.
+    pub async fn convert(
+        &self,
+        services: &(impl Services + Send + Sync + 'static),
+        value: f64,
+        from: &str,
+        to: &str,
+    ) -> Result<f64, human_errors::Error> {
+        let from = from.to_uppercase();
+        let to = to.to_uppercase();
+
+        if from == to {
+            return Ok(value);
+        }
+
+        let rates = self.list(services).await?;
+
+        let lookup = |code: &str| -> Result<f64, human_errors::Error> {
+            if code == "EUR" {
+                return Ok(1.0);
+            }
+
+            rates
+                .iter()
+                .find(|rate| rate.currency == code)
+                .map(|rate| rate.rate)
+                .ok_or_else(|| {
+                    human_errors::user(
+                        format!("The ECB feed does not provide an exchange rate for '{code}'."),
+                        &[
+                            "Check that the currency code is a valid ISO 4217 code.",
+                            "The European Central Bank only publishes rates for a limited set of currencies.",
+                        ],
+                    )
+                })
+        };
+
+        let from_rate = lookup(&from)?;
+        let to_rate = lookup(&to)?;
+
+        // Every rate is expressed relative to the Euro, so we convert the value
+        // into Euros first and then into the target currency.
+        Ok(value / from_rate * to_rate)
+    }
+}
+
+#[async_trait::async_trait]
+impl Collector for EcbRateCollector {
+    type Item = EcbExchangeRate;
+
+    /// Returns the EUR-relative exchange rates, fetching and parsing the ECB
+    /// feed when the cached copy is older than 24 hours.
+    #[instrument("collectors.ecb_rates.list", skip(self, services), err(Display))]
+    async fn list(
+        &self,
+        services: &(impl Services + Send + Sync + 'static),
+    ) -> Result<Vec<Self::Item>, human_errors::Error> {
+        let client = services.http_client();
+        let url = self.url.clone();
+
+        services
+            .cache()
+            .cached(
+                "ecb/rates",
+                url.clone(),
+                move || {
+                    Box::pin(async move {
+                        let response = client.get(&url).send().await.wrap_system_err(
+                            format!("Failed to fetch exchange rates from the ECB feed at '{url}'."),
+                            &[
+                                "Check that the ECB feed is reachable from this host.",
+                                "Check that your network connection is working properly.",
+                            ],
+                        )?;
+
+                        let response = response.error_for_status().wrap_system_err(
+                            "The ECB feed returned an unexpected error status.",
+                            &["The European Central Bank service may be temporarily unavailable."],
+                        )?;
+
+                        let body = response.text().await.wrap_system_err(
+                            "Failed to read the response body from the ECB feed.",
+                            &["The European Central Bank service may be temporarily unavailable."],
+                        )?;
+
+                        parse_ecb_rates(&body)
+                    })
+                },
+                chrono::Duration::hours(24),
+            )
+            .await
+    }
+}
+
+/// The deserialised ECB envelope. Only the nested `Cube` hierarchy is of
+/// interest; the `gesmes:` metadata elements are ignored.
+#[derive(Debug, Deserialize)]
+struct Envelope {
+    #[serde(rename = "Cube")]
+    cube: CubeRoot,
+}
+
+#[derive(Debug, Deserialize)]
+struct CubeRoot {
+    /// The feed nests one dated `Cube` per day. The daily feed contains a
+    /// single entry, but we accept several so the same parser works for the
+    /// historical feeds.
+    #[serde(rename = "Cube", default)]
+    days: Vec<CubeDay>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CubeDay {
+    #[serde(rename = "Cube", default)]
+    rates: Vec<CubeRate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CubeRate {
+    #[serde(rename = "@currency")]
+    currency: String,
+    #[serde(rename = "@rate")]
+    rate: f64,
+}
+
+/// Parses the ECB `eurofxref` XML document into a flat list of EUR-relative
+/// exchange rates, using the most recent dated block in the feed.
+fn parse_ecb_rates(xml: &str) -> Result<Vec<EcbExchangeRate>, human_errors::Error> {
+    let envelope: Envelope = quick_xml::de::from_str(xml).wrap_system_err(
+        "Failed to parse the exchange rate feed returned by the ECB.",
+        &["The European Central Bank may have changed the format of its feed."],
+    )?;
+
+    let rates = envelope
+        .cube
+        .days
+        .into_iter()
+        .next()
+        .map(|day| {
+            day.rates
+                .into_iter()
+                .map(|rate| EcbExchangeRate {
+                    currency: rate.currency.to_uppercase(),
+                    rate: rate.rate,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if rates.is_empty() {
+        return Err(human_errors::system(
+            "The ECB feed did not contain any exchange rates.",
+            &["The European Central Bank service may be temporarily unavailable."],
+        ));
+    }
+
+    Ok(rates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::mock_services;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const SAMPLE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+    <gesmes:subject>Reference rates</gesmes:subject>
+    <gesmes:Sender>
+        <gesmes:name>European Central Bank</gesmes:name>
+    </gesmes:Sender>
+    <Cube>
+        <Cube time="2024-01-15">
+            <Cube currency="USD" rate="1.0945"/>
+            <Cube currency="GBP" rate="0.86290"/>
+            <Cube currency="JPY" rate="158.27"/>
+        </Cube>
+    </Cube>
+</gesmes:Envelope>"#;
+
+    #[test]
+    fn parse_extracts_all_rates() {
+        let rates = parse_ecb_rates(SAMPLE).expect("sample should parse");
+
+        assert_eq!(rates.len(), 3);
+        assert_eq!(
+            rates[0],
+            EcbExchangeRate {
+                currency: "USD".to_string(),
+                rate: 1.0945,
+            }
+        );
+        assert_eq!(rates[2].currency, "JPY");
+        assert_eq!(rates[2].rate, 158.27);
+    }
+
+    #[test]
+    fn parse_rejects_empty_feed() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+    <Cube></Cube>
+</gesmes:Envelope>"#;
+
+        assert!(parse_ecb_rates(xml).is_err());
+    }
+
+    async fn mock_ecb() -> MockServer {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/eurofxref-daily.xml"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE))
+            .mount(&mock_server)
+            .await;
+        mock_server
+    }
+
+    #[tokio::test]
+    async fn list_returns_rates() {
+        let mock_server = mock_ecb().await;
+        let collector =
+            EcbRateCollector::new_with_url(format!("{}/eurofxref-daily.xml", mock_server.uri()));
+        let services = mock_services().await.unwrap();
+
+        let rates = collector.list(&services).await.unwrap();
+        assert_eq!(rates.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn convert_same_currency_is_identity() {
+        let collector = EcbRateCollector::new_with_url("http://example.invalid/feed.xml");
+        let services = mock_services().await.unwrap();
+
+        // No HTTP request should be made when the currencies match.
+        let result = collector
+            .convert(&services, 123.45, "usd", "USD")
+            .await
+            .unwrap();
+        assert_eq!(result, 123.45);
+    }
+
+    #[tokio::test]
+    async fn convert_from_eur() {
+        let mock_server = mock_ecb().await;
+        let collector =
+            EcbRateCollector::new_with_url(format!("{}/eurofxref-daily.xml", mock_server.uri()));
+        let services = mock_services().await.unwrap();
+
+        let result = collector
+            .convert(&services, 100.0, "EUR", "USD")
+            .await
+            .unwrap();
+        assert!((result - 109.45).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn convert_to_eur() {
+        let mock_server = mock_ecb().await;
+        let collector =
+            EcbRateCollector::new_with_url(format!("{}/eurofxref-daily.xml", mock_server.uri()));
+        let services = mock_services().await.unwrap();
+
+        let result = collector
+            .convert(&services, 109.45, "USD", "EUR")
+            .await
+            .unwrap();
+        assert!((result - 100.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn convert_cross_currency() {
+        let mock_server = mock_ecb().await;
+        let collector =
+            EcbRateCollector::new_with_url(format!("{}/eurofxref-daily.xml", mock_server.uri()));
+        let services = mock_services().await.unwrap();
+
+        // 109.45 USD -> 100 EUR -> 86.29 GBP
+        let result = collector
+            .convert(&services, 109.45, "USD", "GBP")
+            .await
+            .unwrap();
+        assert!((result - 86.29).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn convert_unknown_currency_errors() {
+        let mock_server = mock_ecb().await;
+        let collector =
+            EcbRateCollector::new_with_url(format!("{}/eurofxref-daily.xml", mock_server.uri()));
+        let services = mock_services().await.unwrap();
+
+        assert!(
+            collector
+                .convert(&services, 100.0, "USD", "ZZZ")
+                .await
+                .is_err()
+        );
+    }
+}

--- a/agent/src/collectors/mod.rs
+++ b/agent/src/collectors/mod.rs
@@ -2,6 +2,7 @@ mod differential;
 mod incremental;
 
 mod calendar;
+mod ecb_rates;
 mod github_notifications;
 mod github_releases;
 mod rss;
@@ -14,6 +15,7 @@ pub use differential::{Diff, DifferentialCollector};
 pub use incremental::IncrementalCollector;
 
 pub use calendar::CalendarCollector;
+pub use ecb_rates::EcbRateCollector;
 pub use github_notifications::{GitHubNotificationsCollector, GitHubSubjectInformation};
 pub use github_releases::GitHubReleasesCollector;
 pub use rss::{RssCollector, RssWatermark};

--- a/agent/src/jobs/ynab_stocks.rs
+++ b/agent/src/jobs/ynab_stocks.rs
@@ -5,6 +5,7 @@ use rust_ynab::{Account, ClearedStatus, Client, NewTransaction, PlanId};
 use uuid::Uuid;
 use yfinance_rs::{Ticker, YfClient};
 
+use crate::collectors::EcbRateCollector;
 use crate::parsers::parse_key_value_pairs;
 use crate::prelude::*;
 
@@ -115,6 +116,7 @@ impl Job for YnabStocksWorkflow {
         )?;
 
         let yf = YfClient::default();
+        let ecb = EcbRateCollector::new();
 
         let budget = job.budget;
         let plan = PlanId::Id(budget);
@@ -173,14 +175,16 @@ impl Job for YnabStocksWorkflow {
             let mut values = Vec::with_capacity(spec.holdings.len());
             for (symbol, quantity) in &spec.holdings {
                 let quote = fetch_quote(&yf, services, symbol).await?;
-                let rate = fetch_rate(&yf, services, &quote.currency, &budget_currency).await?;
                 let native_value = quantity * quote.price;
+                let value = ecb
+                    .convert(services, native_value, &quote.currency, &budget_currency)
+                    .await?;
                 values.push(StockValue {
                     symbol: symbol.clone(),
                     native_currency: quote.currency,
                     native_price: quote.price,
                     native_value,
-                    value: native_value * rate,
+                    value,
                 });
             }
 
@@ -195,8 +199,8 @@ impl Job for YnabStocksWorkflow {
             let cost_basis = match spec.cost_basis.as_deref() {
                 Some(raw) => match parse_currency_value(raw) {
                     Some((Some(ccy), amount)) => {
-                        let rate = fetch_rate(&yf, services, &ccy, &budget_currency).await?;
-                        amount * rate
+                        ecb.convert(services, amount, &ccy, &budget_currency)
+                            .await?
                     }
                     Some((None, amount)) => amount,
                     None => 0.0,
@@ -302,58 +306,6 @@ async fn fetch_quote(
                         price: amount,
                         currency: price.currency().code().to_string(),
                     })
-                })
-            },
-            chrono::Duration::hours(12),
-        )
-        .await
-}
-
-/// Fetches the exchange rate from `from` to `to`, caching the result for
-/// 12 hours. Returns `1.0` when the currencies match.
-async fn fetch_rate(
-    yf: &YfClient,
-    services: &(impl Services + Send + Sync + 'static),
-    from: &str,
-    to: &str,
-) -> Result<f64, human_errors::Error> {
-    let from = from.to_uppercase();
-    let to = to.to_uppercase();
-
-    if from == to {
-        return Ok(1.0);
-    }
-
-    let yf = yf.clone();
-    let key = format!("{from}:{to}");
-    let pair = format!("{from}{to}=X");
-
-    services
-        .cache()
-        .cached(
-            "ynab/stocks/fx",
-            key,
-            move || {
-                Box::pin(async move {
-                    let ticker = Ticker::new(&yf, pair.as_str());
-                    let quote = ticker.quote().await.wrap_system_err(
-                        format!("Failed to fetch the exchange rate '{pair}' from Yahoo Finance."),
-                        &["Check that both currency codes are valid ISO currency codes."],
-                    )?;
-
-                    let price = quote.price.ok_or_else(|| {
-                        human_errors::system(
-                            format!("Yahoo Finance did not return an exchange rate for '{pair}'."),
-                            &["The currency pair may not be supported by Yahoo Finance."],
-                        )
-                    })?;
-
-                    let rate = price.amount().to_string().parse::<f64>().wrap_system_err(
-                        format!("Failed to parse the exchange rate returned for '{pair}'."),
-                        &["Report this issue to the development team on GitHub."],
-                    )?;
-
-                    Ok(rate)
                 })
             },
             chrono::Duration::hours(12),


### PR DESCRIPTION
## Summary

Switches daily exchange-rate conversions from Yahoo Finance to the European Central Bank's [`eurofxref-daily.xml`](https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml) reference feed, which is far more stable and isn't aggressively rate limited.

## Changes

- **New `EcbRateCollector`** (`agent/src/collectors/ecb_rates.rs`):
  - Implements the `Collector` trait; `list()` fetches and parses the ECB feed (nested `Cube` XML via `quick-xml` serde) into EUR-relative `EcbExchangeRate` pairs.
  - The parsed rate table is cached for **24h** (the ECB publishes once per working day), keyed by feed URL.
  - Exposes `convert(services, value, from, to)`: EUR-based conversion (`value / rate[from] * rate[to]`), case-insensitive, treats `EUR` as the base, short-circuits identical currencies without a fetch, and returns a helpful user error for unsupported currencies.
- **`ynab_stocks` job**: drops the Yahoo Finance `fetch_rate` helper and uses `EcbRateCollector::convert` for both holding valuation and cost-basis conversion. Stock *quotes* still come from Yahoo Finance.
- Adds the `quick-xml` dependency (`serialize` feature) and registers the new collector module.

## Testing

- 8 new unit/integration tests (XML parsing, empty-feed rejection, `list`, identity conversion, EUR↔, cross-currency, and unknown-currency error) using `wiremock`.
- Full agent suite: **333 passed, 0 failed**. `cargo fmt --check` clean; no new clippy warnings.
