### PR TITLE
feat: use AlphaVantage for stock quotes and exchange rates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.1",
- "sha1 0.11.0",
+ "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie 0.16.2",
+ "cookie",
  "derive_more",
  "encoding_rs",
  "foldhash 0.1.5",
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -190,17 +190,6 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
 
 [[package]]
 name = "ahash"
@@ -311,12 +300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +329,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -407,7 +390,6 @@ dependencies = [
  "urlencoding",
  "uuid",
  "wiremock",
- "yfinance-rs",
 ]
 
 [[package]]
@@ -508,21 +490,6 @@ name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -540,30 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -594,28 +537,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,7 +557,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d4f7ea9ab08310fba58c0010e3c203aaa2b6464f1d4886d36855d99b6b6036"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "chrono",
  "chrono-tz",
  "hashify",
@@ -705,7 +626,6 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
- "serde",
 ]
 
 [[package]]
@@ -739,7 +659,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -805,8 +725,6 @@ checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
- "flate2",
- "memchr",
 ]
 
 [[package]]
@@ -851,35 +769,6 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie 0.18.1",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -1013,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1046,7 +935,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1057,7 +946,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1073,12 +962,6 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -1135,7 +1018,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1145,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1167,7 +1050,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1201,16 +1084,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
+ "syn",
 ]
 
 [[package]]
@@ -1383,12 +1257,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,7 +1338,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1637,15 +1505,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1685,7 +1544,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2178,32 +2037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "isin"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bcf2544150282ebe712b4615813c1986bb014564928b1c4a4a567402d6bf02"
-
-[[package]]
-name = "iso_country"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20633e788d3948ea7336861fdb09ec247f5dae4267e8f0743fa97de26c28624d"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "iso_currency"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed4b3f0921193400b1df556228bfd917c57c7fa38bda904d552653c5c3b641b"
-dependencies = [
- "iso_country",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,7 +2089,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2275,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2364,12 +2197,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -2508,12 +2335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,7 +2470,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2774,127 +2595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paft"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3995b75c63ac2c9291e97b958ef52e42af3b0a48589b8139d8176535cb17b8"
-dependencies = [
- "iso_currency",
- "paft-aggregates",
- "paft-core",
- "paft-decimal",
- "paft-domain",
- "paft-fundamentals",
- "paft-market",
- "paft-money",
- "paft-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "paft-aggregates"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56199dd75535a86e54086d9cebc96573ce089f3200509195b5d1baa59746103"
-dependencies = [
- "chrono",
- "paft-domain",
- "paft-money",
- "serde",
-]
-
-[[package]]
-name = "paft-core"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec022386ad00b0934e1de3d0658ad77ad88da78e25a8c1504a7d469e890958b"
-dependencies = [
- "chrono",
- "paft-utils",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "paft-decimal"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b83a121e6f3c0c041b833fb448e7d31c5edecb6d2758cea2246e88c9f3cba42"
-dependencies = [
- "rust_decimal",
-]
-
-[[package]]
-name = "paft-domain"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e7c645f64a8eaf5553443030577c40bf75c4d36be57a991a806c92baa4ea8"
-dependencies = [
- "chrono",
- "isin",
- "paft-core",
- "paft-utils",
- "serde",
- "smol_str",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "paft-fundamentals"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5562b5687159518fa7066c00faaf805d160e65a6c0189367844bb020d527cd0f"
-dependencies = [
- "chrono",
- "paft-core",
- "paft-decimal",
- "paft-domain",
- "paft-money",
- "paft-utils",
- "serde",
-]
-
-[[package]]
-name = "paft-market"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95acda9df87959a08dbce715ada0008adb80dd9e8d28b8b27f7b48efd6381b44"
-dependencies = [
- "bitflags 2.12.1",
- "chrono",
- "chrono-tz",
- "paft-decimal",
- "paft-domain",
- "paft-money",
- "paft-utils",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "paft-money"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b5b85391fd26062d6d27f7d12911dbfc74c17ff7e99a95fd87aad81230f582"
-dependencies = [
- "iso_currency",
- "paft-decimal",
- "paft-utils",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "paft-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcdd035fcd9e6a264fd37b128010e783bfd33531580a0a3fe6d66d16570033e"
-dependencies = [
- "smol_str",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,17 +2638,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
-]
 
 [[package]]
 name = "phf"
@@ -3020,7 +2709,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3033,7 +2722,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3080,7 +2769,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3138,7 +2827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3185,25 +2874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
-dependencies = [
- "heck",
- "itertools",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.117",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,7 +2883,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3223,42 +2893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna",
- "psl-types",
 ]
 
 [[package]]
@@ -3362,12 +2996,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_fmt"
@@ -3520,15 +3148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,8 +3195,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "cookie 0.18.1",
- "cookie_store",
  "encoding_rs",
  "futures-core",
  "h2 0.4.14",
@@ -3672,35 +3289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,7 +3313,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-ident",
 ]
 
@@ -3759,23 +3347,6 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.6",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3944,12 +3515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4104,7 +3669,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4159,17 +3724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -4317,16 +3871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
-name = "smol_str"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
-dependencies = [
- "borsh",
- "serde_core",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,7 +3954,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4418,17 +3962,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -4464,7 +3997,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4517,12 +4050,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4584,7 +4111,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4595,7 +4122,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4701,7 +4228,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4744,22 +4271,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite",
 ]
 
 [[package]]
@@ -4954,7 +4465,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4964,7 +4475,7 @@ source = "git+https://github.com/SierraSoftworks/tracing.git#1440cc1e479e7c18b57
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5062,25 +4573,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.1",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.18",
- "utf-8",
-]
 
 [[package]]
 name = "typenum"
@@ -5296,7 +4788,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -5330,7 +4821,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5479,7 +4970,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5490,7 +4981,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5837,7 +5328,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5853,7 +5344,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5902,15 +5393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xml5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5918,30 +5400,6 @@ checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
-]
-
-[[package]]
-name = "yfinance-rs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b05cd5818c3ad752ac05c351e46d209e2ee6bc9a47605c2a74c4b52c1051727"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "chrono-tz",
- "futures",
- "futures-util",
- "paft",
- "prost",
- "prost-build",
- "reqwest 0.12.28",
- "rust_decimal",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "url",
 ]
 
 [[package]]
@@ -5963,7 +5421,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -5984,7 +5442,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6004,7 +5462,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6025,7 +5483,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6058,7 +5516,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -47,7 +47,6 @@ urlencoding = "2.1.3"
 uuid = { version = "1.23.2", features = ["serde", "v4"] }
 futures = "0.3.32"
 oauth2 = "5.0.0"
-yfinance-rs = "0.8"
 
 [dev-dependencies]
 base64 = "0.22"

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -110,6 +110,9 @@ pub struct ConnectionConfigs {
 
     #[serde(default)]
     pub ynab: YnabConfig,
+
+    #[serde(default)]
+    pub alphavantage: AlphaVantageConfig,
 }
 
 #[derive(Clone, Deserialize, Default)]
@@ -237,6 +240,13 @@ pub struct GitHubConfig {
 #[derive(Default, Clone, Deserialize)]
 pub struct YnabConfig {
     /// The YNAB Personal Access Token used to authenticate with the YNAB API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}
+
+#[derive(Default, Clone, Deserialize)]
+pub struct AlphaVantageConfig {
+    /// The AlphaVantage API key used to fetch stock quotes and exchange rates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 }

--- a/agent/src/jobs/ynab_stocks.rs
+++ b/agent/src/jobs/ynab_stocks.rs
@@ -3,10 +3,10 @@ use std::fmt::Display;
 
 use rust_ynab::{Account, ClearedStatus, Client, NewTransaction, PlanId};
 use uuid::Uuid;
-use yfinance_rs::{Ticker, YfClient};
 
 use crate::parsers::parse_key_value_pairs;
 use crate::prelude::*;
+use crate::services::AlphaVantageClient;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct YnabStocksConfig {
@@ -34,13 +34,6 @@ struct StocksState {
     server_knowledge: Option<i64>,
     #[serde(default)]
     accounts: HashMap<Uuid, Account>,
-}
-
-/// A cached ticker quote, expressed in the instrument's native currency.
-#[derive(Clone, Serialize, Deserialize)]
-struct CachedQuote {
-    price: f64,
-    currency: String,
 }
 
 /// The parsed `/automate:stock` directive from an account note.
@@ -75,10 +68,10 @@ impl Job for YnabStocksWorkflow {
     }
 
     /// Visibility timeout / retry backoff. This job calls the YNAB API and
-    /// Yahoo Finance for quotes, both of which are aggressively rate limited, so
-    /// a failed run backs off for a long time before retrying.
+    /// AlphaVantage for quotes and exchange rates, both of which are rate
+    /// limited, so a failed run backs off for a long time before retrying.
     fn timeout(&self) -> chrono::TimeDelta {
-        chrono::TimeDelta::hours(4)
+        chrono::TimeDelta::hours(1)
     }
 
     #[instrument("workflow.ynab_stocks.setup", skip(self, services), err(Display))]
@@ -114,7 +107,17 @@ impl Job for YnabStocksWorkflow {
             &["Check that your YNAB Personal Access Token is valid."],
         )?;
 
-        let yf = YfClient::default();
+        let alphavantage_api_key =
+            config.connections.alphavantage.api_key.as_deref().ok_or_else(|| {
+                human_errors::user(
+                    "No AlphaVantage API key has been configured.",
+                    &[
+                        "Set `connections.alphavantage.api_key` in your configuration file (for example via the ALPHAVANTAGE_API_KEY environment variable).",
+                        "Claim a free API key from https://www.alphavantage.co/support/#api-key.",
+                    ],
+                )
+            })?;
+        let alphavantage = AlphaVantageClient::new(services.http_client(), alphavantage_api_key);
 
         let budget = job.budget;
         let plan = PlanId::Id(budget);
@@ -172,13 +175,16 @@ impl Job for YnabStocksWorkflow {
             // Value each holding in the budget's currency.
             let mut values = Vec::with_capacity(spec.holdings.len());
             for (symbol, quantity) in &spec.holdings {
-                let quote = fetch_quote(&yf, services, symbol).await?;
-                let rate = fetch_rate(&yf, services, &quote.currency, &budget_currency).await?;
-                let native_value = quantity * quote.price;
+                let price = alphavantage.quote(services, symbol).await?;
+                let currency = alphavantage.currency(services, symbol).await?;
+                let rate = alphavantage
+                    .exchange_rate(services, &currency, &budget_currency)
+                    .await?;
+                let native_value = quantity * price;
                 values.push(StockValue {
                     symbol: symbol.clone(),
-                    native_currency: quote.currency,
-                    native_price: quote.price,
+                    native_currency: currency,
+                    native_price: price,
                     native_value,
                     value: native_value * rate,
                 });
@@ -195,7 +201,9 @@ impl Job for YnabStocksWorkflow {
             let cost_basis = match spec.cost_basis.as_deref() {
                 Some(raw) => match parse_currency_value(raw) {
                     Some((Some(ccy), amount)) => {
-                        let rate = fetch_rate(&yf, services, &ccy, &budget_currency).await?;
+                        let rate = alphavantage
+                            .exchange_rate(services, &ccy, &budget_currency)
+                            .await?;
                         amount * rate
                     }
                     Some((None, amount)) => amount,
@@ -260,105 +268,6 @@ impl Job for YnabStocksWorkflow {
 
         Ok(())
     }
-}
-
-/// Fetches a ticker quote, caching the result for 12 hours.
-async fn fetch_quote(
-    yf: &YfClient,
-    services: &(impl Services + Send + Sync + 'static),
-    symbol: &str,
-) -> Result<CachedQuote, human_errors::Error> {
-    let yf = yf.clone();
-    let symbol_owned = symbol.to_string();
-
-    services
-        .cache()
-        .cached(
-            "ynab/stocks/quotes",
-            symbol.to_string(),
-            move || {
-                Box::pin(async move {
-                    let ticker = Ticker::new(&yf, symbol_owned.as_str());
-                    let quote = ticker.quote().await.wrap_system_err(
-                        format!(
-                            "Failed to fetch a stock quote for '{symbol_owned}' from Yahoo Finance."
-                        ),
-                        &["Check that the ticker symbol is valid and recognised by Yahoo Finance."],
-                    )?;
-
-                    let price = quote.price.ok_or_else(|| {
-                        human_errors::system(
-                            format!("Yahoo Finance did not return a price for '{symbol_owned}'."),
-                            &["The market may be closed or the symbol may be delisted."],
-                        )
-                    })?;
-
-                    let amount = price.amount().to_string().parse::<f64>().wrap_system_err(
-                        format!("Failed to parse the price returned for '{symbol_owned}'."),
-                        &["Report this issue to the development team on GitHub."],
-                    )?;
-
-                    Ok(CachedQuote {
-                        price: amount,
-                        currency: price.currency().code().to_string(),
-                    })
-                })
-            },
-            chrono::Duration::hours(12),
-        )
-        .await
-}
-
-/// Fetches the exchange rate from `from` to `to`, caching the result for
-/// 12 hours. Returns `1.0` when the currencies match.
-async fn fetch_rate(
-    yf: &YfClient,
-    services: &(impl Services + Send + Sync + 'static),
-    from: &str,
-    to: &str,
-) -> Result<f64, human_errors::Error> {
-    let from = from.to_uppercase();
-    let to = to.to_uppercase();
-
-    if from == to {
-        return Ok(1.0);
-    }
-
-    let yf = yf.clone();
-    let key = format!("{from}:{to}");
-    let pair = format!("{from}{to}=X");
-
-    services
-        .cache()
-        .cached(
-            "ynab/stocks/fx",
-            key,
-            move || {
-                Box::pin(async move {
-                    let ticker = Ticker::new(&yf, pair.as_str());
-                    let quote = ticker.quote().await.wrap_system_err(
-                        format!("Failed to fetch the exchange rate '{pair}' from Yahoo Finance."),
-                        &["Check that both currency codes are valid ISO currency codes."],
-                    )?;
-
-                    let price = quote.price.ok_or_else(|| {
-                        human_errors::system(
-                            format!("Yahoo Finance did not return an exchange rate for '{pair}'."),
-                            &["The currency pair may not be supported by Yahoo Finance."],
-                        )
-                    })?;
-
-                    let rate = price.amount().to_string().parse::<f64>().wrap_system_err(
-                        format!("Failed to parse the exchange rate returned for '{pair}'."),
-                        &["Report this issue to the development team on GitHub."],
-                    )?;
-
-                    Ok(rate)
-                })
-            },
-            chrono::Duration::hours(12),
-        )
-        .await
 }
 
 /// Computes the net portfolio value after applying a capital gains tax

--- a/agent/src/services/alphavantage.rs
+++ b/agent/src/services/alphavantage.rs
@@ -1,0 +1,364 @@
+use crate::prelude::*;
+
+/// A minimal AlphaVantage API client used to fetch stock quotes, company
+/// overviews, and currency exchange rates.
+///
+/// AlphaVantage signals errors (invalid symbols, rate limiting, premium-only
+/// endpoints) with a `200 OK` status and a structured JSON body rather than an
+/// HTTP error, so every response is inspected for those markers.
+#[derive(Clone)]
+pub struct AlphaVantageClient {
+    http_client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl AlphaVantageClient {
+    pub fn new(http_client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self {
+            http_client,
+            api_key: api_key.into(),
+            base_url: "https://www.alphavantage.co".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_with_url(
+        http_client: reqwest::Client,
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            http_client,
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+        }
+    }
+
+    /// Fetches the latest price for a ticker symbol via the `GLOBAL_QUOTE`
+    /// endpoint, caching the result for 24 hours.
+    pub async fn quote(
+        &self,
+        services: &(impl Services + Send + Sync + 'static),
+        symbol: &str,
+    ) -> Result<f64, human_errors::Error> {
+        let client = self.clone();
+        let symbol_owned = symbol.to_string();
+
+        services
+            .cache()
+            .cached(
+                "alphavantage/quote",
+                symbol.to_string(),
+                move || {
+                    Box::pin(async move {
+                        let body = client
+                            .get(&[("function", "GLOBAL_QUOTE"), ("symbol", &symbol_owned)])
+                            .await?;
+
+                        let price = body
+                            .get("Global Quote")
+                            .and_then(|quote| quote.get("05. price"))
+                            .and_then(|price| price.as_str())
+                            .ok_or_else(|| {
+                                human_errors::system(
+                                    format!(
+                                        "AlphaVantage did not return a price for '{symbol_owned}'."
+                                    ),
+                                    &[
+                                        "Check that the ticker symbol is valid and recognised by AlphaVantage.",
+                                        "The market may be closed or you may have exceeded your API rate limit.",
+                                    ],
+                                )
+                            })?;
+
+                        price.parse::<f64>().wrap_system_err(
+                            format!("Failed to parse the price returned for '{symbol_owned}'."),
+                            &["Report this issue to the development team on GitHub."],
+                        )
+                    })
+                },
+                chrono::Duration::hours(24),
+            )
+            .await
+    }
+
+    /// Looks up the trading currency for a symbol via the `OVERVIEW` endpoint,
+    /// caching the result for six months (a symbol's currency rarely changes).
+    /// Falls back to `USD` when AlphaVantage does not report a currency, which
+    /// happens for non-equity instruments such as ETFs.
+    pub async fn currency(
+        &self,
+        services: &(impl Services + Send + Sync + 'static),
+        symbol: &str,
+    ) -> Result<String, human_errors::Error> {
+        let client = self.clone();
+        let symbol_owned = symbol.to_string();
+
+        services
+            .cache()
+            .cached(
+                "alphavantage/overview",
+                symbol.to_string(),
+                move || {
+                    Box::pin(async move {
+                        let body = client
+                            .get(&[("function", "OVERVIEW"), ("symbol", &symbol_owned)])
+                            .await?;
+
+                        let currency = body
+                            .get("Currency")
+                            .and_then(|currency| currency.as_str())
+                            .filter(|currency| !currency.is_empty())
+                            .unwrap_or("USD")
+                            .to_uppercase();
+
+                        Ok(currency)
+                    })
+                },
+                chrono::Duration::days(182),
+            )
+            .await
+    }
+
+    /// Fetches the exchange rate from `from` to `to` via the
+    /// `CURRENCY_EXCHANGE_RATE` endpoint, caching the result for 24 hours.
+    /// Returns `1.0` when the currencies match.
+    pub async fn exchange_rate(
+        &self,
+        services: &(impl Services + Send + Sync + 'static),
+        from: &str,
+        to: &str,
+    ) -> Result<f64, human_errors::Error> {
+        let from = from.to_uppercase();
+        let to = to.to_uppercase();
+
+        if from == to {
+            return Ok(1.0);
+        }
+
+        let client = self.clone();
+        let key = format!("{from}:{to}");
+
+        services
+            .cache()
+            .cached(
+                "alphavantage/forex",
+                key,
+                move || {
+                    Box::pin(async move {
+                        let body = client
+                            .get(&[
+                                ("function", "CURRENCY_EXCHANGE_RATE"),
+                                ("from_currency", &from),
+                                ("to_currency", &to),
+                            ])
+                            .await?;
+
+                        let rate = body
+                            .get("Realtime Currency Exchange Rate")
+                            .and_then(|rate| rate.get("5. Exchange Rate"))
+                            .and_then(|rate| rate.as_str())
+                            .ok_or_else(|| {
+                                human_errors::system(
+                                    format!(
+                                        "AlphaVantage did not return an exchange rate from {from} to {to}."
+                                    ),
+                                    &["Check that both currency codes are valid ISO currency codes."],
+                                )
+                            })?;
+
+                        rate.parse::<f64>().wrap_system_err(
+                            format!("Failed to parse the exchange rate from {from} to {to}."),
+                            &["Report this issue to the development team on GitHub."],
+                        )
+                    })
+                },
+                chrono::Duration::hours(24),
+            )
+            .await
+    }
+
+    /// Performs a `GET /query` request against the AlphaVantage API and returns
+    /// the parsed JSON body, surfacing the structured error responses
+    /// AlphaVantage returns with a `200 OK` status (invalid symbols, rate
+    /// limiting, and premium-only endpoints).
+    async fn get(&self, params: &[(&str, &str)]) -> Result<serde_json::Value, human_errors::Error> {
+        let url = format!("{}/query", self.base_url);
+
+        let mut query = params.to_vec();
+        query.push(("apikey", &self.api_key));
+
+        let response = self
+            .http_client
+            .get(&url)
+            .query(&query)
+            .send()
+            .await
+            .wrap_system_err(
+                "Failed to contact the AlphaVantage API.",
+                &[
+                    "Check that the AlphaVantage API is reachable from this host.",
+                    "Check that your network connection is working properly.",
+                ],
+            )?;
+
+        let response = response.error_for_status().wrap_system_err(
+            "The AlphaVantage API returned an unexpected error status.",
+            &["The AlphaVantage service may be temporarily unavailable."],
+        )?;
+
+        let body: serde_json::Value = response.json().await.wrap_system_err(
+            "Failed to parse the response from the AlphaVantage API.",
+            &["The AlphaVantage service may have returned an unexpected response."],
+        )?;
+
+        if let Some(message) = body.get("Error Message").and_then(|value| value.as_str()) {
+            return Err(human_errors::user(
+                format!("AlphaVantage rejected the request: {message}"),
+                &["Check that the ticker symbol or currency codes are valid."],
+            ));
+        }
+
+        // `Note` is returned when the request rate limit is exceeded;
+        // `Information` is returned when an endpoint requires a premium
+        // subscription. Both are transient from the job's perspective, so they
+        // are treated as system errors that allow the job to retry later.
+        if let Some(message) = body
+            .get("Note")
+            .or_else(|| body.get("Information"))
+            .and_then(|value| value.as_str())
+        {
+            return Err(human_errors::system(
+                format!("AlphaVantage could not service the request: {message}"),
+                &[
+                    "You may have exceeded your AlphaVantage API rate limit; the job will retry later.",
+                ],
+            ));
+        }
+
+        Ok(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::mock_services;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn mock_alphavantage(function: &str, body: &str) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/query"))
+            .and(query_param("function", function))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn quote_returns_price() {
+        let server = mock_alphavantage(
+            "GLOBAL_QUOTE",
+            r#"{"Global Quote":{"01. symbol":"MSFT","05. price":"425.2700"}}"#,
+        )
+        .await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        let price = client.quote(&services, "MSFT").await.unwrap();
+        assert!((price - 425.27).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn quote_surfaces_invalid_symbol_error() {
+        let server =
+            mock_alphavantage("GLOBAL_QUOTE", r#"{"Error Message":"Invalid API call."}"#).await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        assert!(client.quote(&services, "NOPE").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn quote_surfaces_rate_limit_note() {
+        let server = mock_alphavantage(
+            "GLOBAL_QUOTE",
+            r#"{"Note":"Thank you for using Alpha Vantage! Our standard API rate limit is 25 requests per day."}"#,
+        )
+        .await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        assert!(client.quote(&services, "MSFT").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn quote_surfaces_premium_information() {
+        let server = mock_alphavantage(
+            "GLOBAL_QUOTE",
+            r#"{"Information":"This is a premium endpoint."}"#,
+        )
+        .await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        assert!(client.quote(&services, "MSFT").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn currency_reads_overview() {
+        let server = mock_alphavantage(
+            "OVERVIEW",
+            r#"{"Symbol":"VOD.LON","Currency":"GBP","Name":"Vodafone"}"#,
+        )
+        .await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        let currency = client.currency(&services, "VOD.LON").await.unwrap();
+        assert_eq!(currency, "GBP");
+    }
+
+    #[tokio::test]
+    async fn currency_defaults_to_usd_when_absent() {
+        let server = mock_alphavantage("OVERVIEW", r#"{}"#).await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        let currency = client.currency(&services, "SPY").await.unwrap();
+        assert_eq!(currency, "USD");
+    }
+
+    #[tokio::test]
+    async fn exchange_rate_returns_rate() {
+        let server = mock_alphavantage(
+            "CURRENCY_EXCHANGE_RATE",
+            r#"{"Realtime Currency Exchange Rate":{"1. From_Currency Code":"USD","3. To_Currency Code":"GBP","5. Exchange Rate":"0.79000"}}"#,
+        )
+        .await;
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(services.http_client(), "demo", server.uri());
+
+        let rate = client.exchange_rate(&services, "USD", "GBP").await.unwrap();
+        assert!((rate - 0.79).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn exchange_rate_same_currency_is_identity_without_request() {
+        // No mock server is configured, so any HTTP request would fail; the
+        // matching-currency short-circuit must avoid it entirely.
+        let services = mock_services().await.unwrap();
+        let client = AlphaVantageClient::new_with_url(
+            services.http_client(),
+            "demo",
+            "http://example.invalid",
+        );
+
+        let rate = client.exchange_rate(&services, "usd", "USD").await.unwrap();
+        assert_eq!(rate, 1.0);
+    }
+}

--- a/agent/src/services/mod.rs
+++ b/agent/src/services/mod.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use crate::config::Config;
 
+mod alphavantage;
+
+pub use alphavantage::AlphaVantageClient;
+
 /// The concrete [`Services`] implementation used by the running application and
 /// the job consumer.
 ///

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,6 +8,12 @@ api_key = "${{ env.TODOIST_API_KEY }}"
 # A YNAB Personal Access Token, created from your YNAB account settings.
 api_key = "${{ env.YNAB_API_KEY }}"
 
+[connections.alphavantage]
+# An AlphaVantage API key, used by the YNAB stocks workflow to fetch stock
+# quotes and currency exchange rates. Claim a free key from
+# https://www.alphavantage.co/support/#api-key.
+api_key = "${{ env.ALPHAVANTAGE_API_KEY }}"
+
 [oauth2.spotify]
 name = "Spotify"
 jobs = ["workflow/spotify-yearly-playlist"]


### PR DESCRIPTION
## Summary

Replaces the `yfinance` dependency in the `ynab_stocks` job with [AlphaVantage](https://www.alphavantage.co)'s APIs to fetch stock quotes and currency exchange rates.

- **`GLOBAL_QUOTE`** — fetches the latest price for each holding.
- **`CURRENCY_EXCHANGE_RATE`** — converts holding/cost-basis currencies into the budget currency (short-circuits to `1.0` for matching currencies).
- **`OVERVIEW`** — resolves the reporting currency for each ticker, since `GLOBAL_QUOTE` (unlike Yahoo) doesn't return one; defaults to `USD` when absent (e.g. ETFs).

## Implementation

- New `agent::services` module hosts `AlphaVantageClient`, which holds its own `reqwest::Client` and owns the HTTP request logic (`get`) internally.
- Responses are cached in the `alphavantage/quote` (24h), `alphavantage/forex` (24h), and `alphavantage/overview` (6 months) namespaces to stay within the free tier's request limits.
- AlphaVantage returns errors with a `200 OK` status and JSON markers (`Error Message`, `Note`, `Information`); these are surfaced as user or system errors so rate limits trigger retries rather than failing outright.
- `services.rs` moved to `services/mod.rs` to host the new submodule.

## Configuration

Access is configured via the config file:

```toml
[connections.alphavantage]
api_key = "${ env.ALPHAVANTAGE_API_KEY }"
```

A free key can be claimed from https://www.alphavantage.co/support/#api-key.

## Testing

- 8 new wiremock-based tests cover quote parsing, currency resolution (incl. the `USD` default), exchange-rate parsing, the same-currency identity short-circuit, and the three error envelopes.
- Full suite: 333 tests pass; `cargo fmt --all --check` clean; no new clippy warnings.