### PR TITLE
Sort queue entries by idempotency key

### DIFF
--- a/ui/src/pages/kv.rs
+++ b/ui/src/pages/kv.rs
@@ -93,7 +93,7 @@ pub fn kv_partitions(
     groups
         .into_iter()
         .map(|(partition, mut entries)| {
-            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            entries.sort_by(|a, b| b.0.cmp(&a.0));
             let entries = entries
                 .into_iter()
                 .map(|(key, value)| {

--- a/ui/src/pages/kv.rs
+++ b/ui/src/pages/kv.rs
@@ -93,7 +93,7 @@ pub fn kv_partitions(
     groups
         .into_iter()
         .map(|(partition, mut entries)| {
-            entries.sort_by(|a, b| b.0.cmp(&a.0));
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
             let entries = entries
                 .into_iter()
                 .map(|(key, value)| {

--- a/ui/src/pages/queue.rs
+++ b/ui/src/pages/queue.rs
@@ -57,18 +57,19 @@ fn to_display(msg: &QueueMessage) -> QueueMessageDisplay {
 }
 
 /// Groups the queued messages into [`BrowserPartition`]s of kind `queue`,
-/// preserving the schedule order within each partition. Each message is rendered
-/// with a schedule/availability/state timeline plus trigger and delete controls.
+/// ordering messages by their idempotency key within each partition. Each
+/// message is rendered with a schedule/availability/state timeline plus trigger
+/// and delete controls.
 pub fn queue_partitions(
     messages: &[QueueMessage],
     on_trigger: &Callback<(String, String, serde_json::Value)>,
     on_delete: &Callback<(String, String)>,
 ) -> Vec<BrowserPartition> {
     let mut display: Vec<QueueMessageDisplay> = messages.iter().map(to_display).collect();
-    display.sort_by(|a, b| a.scheduled_at.cmp(&b.scheduled_at));
+    display.sort_by(|a, b| a.key.cmp(&b.key));
 
-    // Group by partition (alphabetically), preserving the schedule order within
-    // each partition.
+    // Group by partition (alphabetically), preserving the idempotency-key order
+    // within each partition.
     let mut groups: BTreeMap<String, Vec<QueueMessageDisplay>> = BTreeMap::new();
     for msg in display {
         groups.entry(msg.partition.clone()).or_default().push(msg);


### PR DESCRIPTION
## Summary

Queue entries in the admin partition browser previously had no clearly visible sort order (they were ordered by schedule time). This sorts them by their **idempotency key** within each partition, matching the key-based ordering already used by the key-value browser.

## Changes

- `ui/src/pages/queue.rs`: order messages by `key` (the idempotency key) instead of `scheduled_at`; docstring/comments updated to match.
- `ui/src/pages/kv.rs`: unchanged from `main` — the key-value browser keeps its original ascending key order.

https://claude.ai/code/session_01D97FAXwbUr4ULLnosk7nuw