### PR TITLE
fix(rss): embed raw article URL in Todoist task links

### DIFF
--- a/agent/src/jobs/rss.rs
+++ b/agent/src/jobs/rss.rs
@@ -94,7 +94,7 @@ impl Job for RssWorkflow {
                     title: format!(
                         "[{}]({}): {}",
                         &job.name,
-                        urlencoding::encode(&item.links[0].href),
+                        &item.links[0].href,
                         item.title
                             .as_ref()
                             .map(|t| t.content.as_str())


### PR DESCRIPTION
## Problem

RSS feed tasks created in Todoist had broken article links. The Markdown link target was being URL-encoded, e.g. `https%3A%2F%2Fwww.ynab.com%2Fwhats-new%2F...`. Because the encoded form has no recognizable `:` scheme separator, Todoist treated it as a relative path and expanded it against its own site:

```
https://app.todoist.com/app/task/https%3A%2F%2Fwww.ynab.com%2Fwhats-new%2Fthe-clearest-way-to-enter-transactions
```

instead of the intended:

```
https://www.ynab.com/whats-new/the-clearest-way-to-enter-transactions
```

## Fix

`agent/src/jobs/rss.rs` was wrapping the article href in `urlencoding::encode()` when building the Markdown link in the task title. The `youtube` and `xkcd` jobs embed the raw URL directly and resolve correctly, so this brings the RSS job in line with them.

```rust
-    urlencoding::encode(&item.links[0].href),
+    &item.links[0].href,
```

The `urlencoding` crate is still used elsewhere (`webhooks/azure_monitor.rs`, `collectors/xkcd.rs`), so the dependency stays.

## Testing

- `cargo build` succeeds (only a pre-existing, unrelated `unused import` warning).

https://claude.ai/code/session_011adTxJn44hUBCy96tVtJDB

---
_Generated by [Claude Code](https://claude.ai/code/session_011adTxJn44hUBCy96tVtJDB)_