### PR TITLE
ci: add per-target cache key to matrixed build job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,6 +189,8 @@ jobs:
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Fetch Versioned Cargo.toml
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

The `build` job in `.github/workflows/rust.yml` compiles multiple targets via a matrix (Windows/Linux/macOS × amd64/arm64), but its `Swatinem/rust-cache@v2` step had no `key`. As a result all matrix entries shared a single cache key and clobbered each other's caches.

This adds a per-entry key derived from `matrix.target`, which is unique per matrix entry:

```yaml
      - name: Setup Cache
        uses: Swatinem/rust-cache@v2
        with:
          key: ${{ matrix.target }}
```

## Notes

- The single-entry `test` and `ui` jobs already get unique cache keys from their job names, so they are intentionally left unchanged.
- `matrix.target` is defined for every entry in the build matrix, so it's the natural unique discriminator here.

https://claude.ai/code/session_014xeWsZ77eWKsv6N6j9JZcV

---
_Generated by [Claude Code](https://claude.ai/code/session_014xeWsZ77eWKsv6N6j9JZcV)_