### PR TITLE
Set Terraform webhook task due date to webhook receipt time

### DIFF
--- a/agent/src/webhooks/terraform.rs
+++ b/agent/src/webhooks/terraform.rs
@@ -100,7 +100,7 @@ impl Job for TerraformWebhook {
                                 .join("\n"),
                         ),
                         priority: Some(payload.priority()),
-                        due: crate::publishers::TodoistDueDate::None,
+                        due: crate::publishers::TodoistDueDate::DateTime(ctx.scheduled_at()),
                         config: services
                             .config()
                             .connections
@@ -126,7 +126,7 @@ impl Job for TerraformWebhook {
                             ])?
                         )),
                         priority: Some(payload.priority()),
-                        due: crate::publishers::TodoistDueDate::None,
+                        due: crate::publishers::TodoistDueDate::DateTime(ctx.scheduled_at()),
                         config: services
                             .config()
                             .connections


### PR DESCRIPTION
## Summary

Terraform webhook events were creating Todoist tasks with `TodoistDueDate::None`, so they never appeared in the "Today" view. Both Terraform notification variants (Standard and Workplace) now set the due date to the time the webhook was received (`ctx.scheduled_at()`), matching the behaviour of the Sentry and Honeycomb handlers.

A survey of the other webhook handlers confirmed Terraform was the only one missing a date:

| Handler | Due date source |
|---|---|
| Sentry | webhook receipt time |
| Honeycomb | webhook receipt time |
| Grafana | alert `starts_at`, falling back to receipt time |
| Azure Monitor | alert fired time |
| Tailscale | event timestamp |
| **Terraform** | **none → now webhook receipt time** |

## Testing

- `cargo test` — all 335 tests pass.

https://claude.ai/code/session_019t1AXyn5aGzdHN8AXWTfzb

---
_Generated by [Claude Code](https://claude.ai/code/session_019t1AXyn5aGzdHN8AXWTfzb)_