### PR TITLE
fix(web): harden admin auth and gate the OAuth setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,22 @@ header. `POST /api/v1/auth/logout` clears the session cookie.
 
 If you run behind a reverse proxy and want absolute URLs to honour the
 forwarded scheme/host, set `web.trust_proxy = true`; only do so when the
-proxy is trusted, since these headers can otherwise be spoofed.
+proxy is trusted, since these headers can otherwise be spoofed. The same flag
+governs whether `X-Forwarded-For` is trusted when the admin `acl` evaluates
+`client_ip`.
+
+### OAuth setup wizard
+
+Some workflows act on third-party accounts (for example Spotify) that you link
+by walking through an OAuth flow at `/oauth/<provider>/`. The agent drives the
+flow server-side and stores the resulting refresh token. The wizard is protected
+like the admin area: by default it requires you to be signed in as an admin, and
+renders an HTML sign-in prompt (rather than a bare error) if you are not. A
+provider can instead opt into self-service access by setting its own `acl` under
+`[oauth2.<provider>]`, evaluated just like the admin ACL — for example
+`acl = 'true'` lets anyone connect their own account without signing in. Each
+flow is bound to the browser that began it by a single-use `state` value to
+prevent login CSRF.
 
 ## Project layout
 

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -144,10 +144,11 @@ pub struct AdminConfig {
     #[serde(default = "default_admin_acl")]
     pub acl: Filter,
 
-    /// Optional OIDC configuration. When present, requests to the admin API
-    /// must include an `Authorization: Bearer <id_token>` header holding a valid
-    /// ID token issued by the configured provider; the browser obtains this
-    /// token via the Authorization Code + PKCE flow.
+    /// Optional OIDC configuration. When present, requests to the admin API must
+    /// carry a valid session cookie (`automate_session`) holding an ID token
+    /// issued by the configured provider. The agent drives the entire
+    /// Authorization Code + PKCE flow server-side and sets the cookie; the browser
+    /// never handles tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oidc: Option<OidcConfig>,
 }

--- a/agent/src/web/api/auth.rs
+++ b/agent/src/web/api/auth.rs
@@ -248,7 +248,19 @@ pub async fn auth_callback<S: Services>(
 }
 
 /// `POST /api/v1/auth/logout` — clears the session cookie.
-pub async fn auth_logout() -> HttpResponse {
+///
+/// Logout lives in the public `/auth` scope, outside the [`super::api_auth`]
+/// middleware that guards the rest of the API, so it enforces the double-submit
+/// CSRF check itself. Without it a cross-site `POST` could forcibly sign the user
+/// out (the response's `Set-Cookie` clears the session regardless of `SameSite`).
+pub async fn auth_logout(req: HttpRequest) -> HttpResponse {
+    if !super::csrf_ok_request(&req) {
+        return json_error(
+            actix_web::http::StatusCode::FORBIDDEN,
+            "The request could not be verified. Please refresh the page and try again.",
+        );
+    }
+
     let mut removal = Cookie::build(SESSION_COOKIE, "").path(COOKIE_PATH).finish();
     removal.make_removal();
 

--- a/agent/src/web/api/mod.rs
+++ b/agent/src/web/api/mod.rs
@@ -20,6 +20,7 @@ use crate::prelude::*;
 use crate::web::helpers::oidc::{
     AdminRequestFilter, admin_user_from_claims, filterable_claims, validate_token,
 };
+use crate::web::helpers::request::client_ip;
 
 mod auth;
 mod kv;
@@ -159,7 +160,7 @@ pub async fn api_auth<S: Services + Send + Sync + 'static>(
     let filter = AdminRequestFilter {
         method: req.method().as_str(),
         path: req.path(),
-        client_ip: req.peer_addr().map(|addr| addr.ip().to_string()),
+        client_ip: client_ip(config.web.trust_proxy, req.headers(), req.peer_addr()),
         headers: req.headers(),
         claims: filterable.as_ref(),
     };
@@ -167,13 +168,15 @@ pub async fn api_auth<S: Services + Send + Sync + 'static>(
     let allowed = admin.acl.matches(&filter).unwrap_or(false);
 
     if !allowed {
-        let status = if claims.is_some() {
-            actix_web::http::StatusCode::FORBIDDEN
-        } else {
-            actix_web::http::StatusCode::UNAUTHORIZED
-        };
+        // We only reach the ACL check after authentication has already been
+        // resolved: either OIDC is configured and the session validated above, or
+        // OIDC is disabled and there is nothing to sign in to. In both cases a
+        // denial here is a permanent authorization failure, so respond `403`.
+        // Returning `401` would tell the browser to start a sign-in that cannot
+        // change the outcome — and, when OIDC is disabled, would leave the admin
+        // UI bouncing through a sign-in flow that goes nowhere.
         return Ok(req.into_response(json_error(
-            status,
+            actix_web::http::StatusCode::FORBIDDEN,
             "Your account is not permitted to access this resource.",
         )));
     }
@@ -184,21 +187,126 @@ pub async fn api_auth<S: Services + Send + Sync + 'static>(
     next.call(req).await
 }
 
-/// Validates the double-submit CSRF token: the `X-CSRF-Token` header must be
-/// present, non-empty, and equal to the `automate_csrf` cookie value.
+/// Compares the two halves of a double-submit CSRF token: they must both be
+/// present, non-empty, and equal.
+fn csrf_tokens_match(header: Option<&str>, cookie: Option<&str>) -> bool {
+    matches!((header, cookie), (Some(h), Some(c)) if !h.is_empty() && h == c)
+}
+
+/// Validates the double-submit CSRF token on a [`ServiceRequest`]: the
+/// `X-CSRF-Token` header must equal the `automate_csrf` cookie. Used by the
+/// [`api_auth`] middleware.
 fn csrf_ok(req: &ServiceRequest) -> bool {
-    let header = req
-        .headers()
-        .get(CSRF_HEADER)
-        .and_then(|v| v.to_str().ok())
-        .map(str::to_string);
+    let cookie = req.cookie(CSRF_COOKIE);
+    csrf_tokens_match(
+        req.headers().get(CSRF_HEADER).and_then(|v| v.to_str().ok()),
+        cookie.as_ref().map(|c: &Cookie| c.value()),
+    )
+}
 
-    let cookie = req
-        .cookie(CSRF_COOKIE)
-        .map(|c: Cookie| c.value().to_string());
+/// Validates the double-submit CSRF token on an [`actix_web::HttpRequest`]. Used
+/// by the public logout handler, which sits outside the [`api_auth`] middleware
+/// and so must perform the check itself.
+pub(crate) fn csrf_ok_request(req: &actix_web::HttpRequest) -> bool {
+    let cookie = req.cookie(CSRF_COOKIE);
+    csrf_tokens_match(
+        req.headers().get(CSRF_HEADER).and_then(|v| v.to_str().ok()),
+        cookie.as_ref().map(|c: &Cookie| c.value()),
+    )
+}
 
-    match (header, cookie) {
-        (Some(header), Some(cookie)) => !header.is_empty() && header == cookie,
-        _ => false,
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use actix_web::{App, cookie::Cookie as TestCookie, test, web};
+
+    use crate::config::Config;
+    use crate::db::SqliteDatabase;
+    use crate::filter::Filter;
+    use crate::services::ServicesContainer;
+
+    /// Builds a services container with OIDC disabled and the given admin ACL.
+    async fn service_with_acl(acl: &str) -> ServicesContainer<SqliteDatabase> {
+        let db = SqliteDatabase::open_in_memory().await.unwrap();
+        let mut config = Config::default();
+        config.web.admin.acl = Filter::new(acl).unwrap();
+        ServicesContainer::new(config, db)
+    }
+
+    #[actix_web::test]
+    async fn acl_denial_without_oidc_is_forbidden_not_unauthorized() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(service_with_acl("false").await))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/api/v1/me").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        // A denial while OIDC is disabled is permanent — there is nothing to sign
+        // in to — so it must be a 403, never a 401 that would send the admin UI
+        // into a sign-in flow that can never succeed.
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn acl_allow_without_oidc_reports_no_signed_in_user() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(service_with_acl("true").await))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/api/v1/me").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[actix_web::test]
+    async fn mutating_request_without_csrf_is_rejected() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(service_with_acl("true").await))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+
+        let req = test::TestRequest::delete()
+            .uri("/api/v1/kv/cache?key=foo")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn logout_requires_a_matching_csrf_token() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(service_with_acl("true").await))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+
+        // No CSRF token: rejected, so a cross-site POST cannot force a logout.
+        let req = test::TestRequest::post()
+            .uri("/api/v1/auth/logout")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // A matching double-submit header and cookie: accepted.
+        let req = test::TestRequest::post()
+            .uri("/api/v1/auth/logout")
+            .cookie(TestCookie::new(CSRF_COOKIE, "tok"))
+            .insert_header((CSRF_HEADER, "tok"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/agent/src/web/helpers/oidc.rs
+++ b/agent/src/web/helpers/oidc.rs
@@ -13,9 +13,11 @@
 //! resulting ID token is stored in an `HttpOnly` session cookie rather than ever
 //! being exposed to JavaScript.
 //!
-//! The provider's discovery document and signing keys (JWKS) are cached for an
-//! hour via [`crate::db::Cache`] so that we avoid hitting the provider on every
-//! request while still picking up key rotations in a timely fashion.
+//! The provider's discovery document is cached for an hour via
+//! [`crate::db::Cache`] to avoid hitting the provider on every request. The
+//! signing keys (JWKS) are cached for longer (24 hours) because key rotations are
+//! picked up on demand: [`validate_token`] refetches the JWKS when a token
+//! presents an unrecognised `kid`.
 
 use actix_web::http::header::HeaderMap;
 use base64::Engine;
@@ -45,6 +47,17 @@ const ADVICE_PROVIDER: &[&str] = &[
     "Ensure that the `web.admin.oidc.endpoint` points at a valid OIDC provider.",
     "Check that the provider is reachable from this server.",
 ];
+
+/// Cache partition holding the provider's discovery document.
+const DISCOVERY_CACHE_PARTITION: &str = "oidc:discovery";
+
+/// Cache partition holding the provider's signing keys (JWKS).
+const JWKS_CACHE_PARTITION: &str = "oidc:jwks";
+
+/// How long the provider's signing keys (JWKS) are cached. Key rotations are
+/// handled on demand — [`validate_token`] refetches when a token presents an
+/// unknown `kid` — so a long TTL does not risk locking out valid sessions.
+const JWKS_CACHE_TTL_HOURS: i64 = 24;
 
 /// The subset of the OIDC discovery document we rely upon.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -181,7 +194,7 @@ pub async fn discovery<S: Services>(
     services
         .cache()
         .cached(
-            "oidc:discovery",
+            DISCOVERY_CACHE_PARTITION,
             endpoint,
             move || {
                 Box::pin(async move {
@@ -215,19 +228,36 @@ pub async fn discovery<S: Services>(
 }
 
 /// Fetches and caches the JSON Web Key Set used to verify token signatures.
+///
+/// When `force_refresh` is set, any cached key set is dropped first so the
+/// provider is queried afresh. This is used when a token presents a `kid` we
+/// don't recognise — typically because the provider has rotated its signing keys
+/// since we last cached them — so that a rotation doesn't lock out otherwise
+/// valid sessions until the cache expires.
 #[instrument("web.oidc.jwks", skip(services, discovery), err(Display))]
 async fn jwks<S: Services>(
     services: &S,
     discovery: &OidcDiscovery,
+    force_refresh: bool,
 ) -> Result<jsonwebtoken::jwk::JwkSet, human_errors::Error> {
     let jwks_uri = discovery.jwks_uri.clone();
+
+    if force_refresh {
+        // `services.cache()` and `services.kv()` are the same store, so removing
+        // the cache entry here forces the `cached` call below to rebuild it.
+        services
+            .kv()
+            .remove(JWKS_CACHE_PARTITION, jwks_uri.clone())
+            .await?;
+    }
+
     let fetch_uri = jwks_uri.clone();
     let http_client = services.http_client();
 
     services
         .cache()
         .cached(
-            "oidc:jwks",
+            JWKS_CACHE_PARTITION,
             jwks_uri,
             move || {
                 Box::pin(async move {
@@ -254,7 +284,7 @@ async fn jwks<S: Services>(
                     Ok(keys)
                 })
             },
-            chrono::Duration::hours(1),
+            chrono::Duration::hours(JWKS_CACHE_TTL_HOURS),
         )
         .await
 }
@@ -270,9 +300,31 @@ pub async fn validate_token<S: Services>(
     token: &str,
 ) -> Result<serde_json::Map<String, serde_json::Value>, human_errors::Error> {
     let discovery = discovery(services, oidc).await?;
-    let key_set = jwks(services, &discovery).await?;
+    let key_set = jwks(services, &discovery, false).await?;
+
+    // If the token's signing key isn't in the cached JWKS, the provider may have
+    // rotated its keys since we cached them. Refetch once, bypassing the cache,
+    // before rejecting the token so that a key rotation doesn't lock out
+    // otherwise valid sessions for the lifetime of the cache entry.
+    let key_set = if needs_jwks_refresh(&key_set, token) {
+        jwks(services, &discovery, true).await?
+    } else {
+        key_set
+    };
 
     verify_token(&oidc.client_id, &discovery.issuer, &key_set, token)
+}
+
+/// Returns `true` when the token names a signing key (`kid`) that is absent from
+/// the supplied key set, indicating the cached JWKS may be stale (for example
+/// after the provider rotates its keys). A token that cannot be decoded, or one
+/// without a `kid`, returns `false` so the verification path surfaces the real
+/// error rather than triggering a pointless refetch.
+fn needs_jwks_refresh(key_set: &jsonwebtoken::jwk::JwkSet, token: &str) -> bool {
+    match jsonwebtoken::decode_header(token).ok().and_then(|h| h.kid) {
+        Some(kid) => key_set.find(&kid).is_none(),
+        None => false,
+    }
 }
 
 /// Verifies an ID token against a known JWKS, audience, and issuer. This is the
@@ -560,6 +612,83 @@ mod tests {
     fn verify_token_rejects_malformed_tokens() {
         let keys = jsonwebtoken::jwk::JwkSet { keys: vec![] };
         let result = verify_token("client", "https://idp.example.com", &keys, "not-a-jwt");
+        assert!(result.is_err());
+    }
+
+    /// Crafts a token whose header advertises an asymmetric algorithm and the
+    /// given `kid`, with an unverifiable signature. This is enough to exercise the
+    /// header-only `kid` inspection in [`needs_jwks_refresh`].
+    fn rs256_token_with_kid(kid: &str) -> String {
+        use base64::Engine;
+        let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+        let claims = serde_json::json!({ "sub": "user-1" });
+        let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let header_segment = engine.encode(serde_json::to_vec(&header).unwrap());
+        let claims_segment = engine.encode(serde_json::to_vec(&claims).unwrap());
+        format!("{header_segment}.{claims_segment}.sig")
+    }
+
+    #[test]
+    fn needs_jwks_refresh_only_for_unknown_kid() {
+        let empty = jsonwebtoken::jwk::JwkSet { keys: vec![] };
+
+        // A token naming a key absent from the set should trigger a refresh.
+        assert!(needs_jwks_refresh(&empty, &rs256_token_with_kid("rotated")));
+
+        // A token we can't decode, or one without a `kid`, should not.
+        assert!(!needs_jwks_refresh(&empty, "not-a-jwt"));
+        assert!(!needs_jwks_refresh(&empty, &hs256_token(None)));
+    }
+
+    #[tokio::test]
+    async fn validate_token_refetches_jwks_on_unknown_kid() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        let discovery_body = serde_json::json!({
+            "issuer": server.uri(),
+            "authorization_endpoint": format!("{}/authorize", server.uri()),
+            "token_endpoint": format!("{}/token", server.uri()),
+            "jwks_uri": format!("{}/jwks", server.uri()),
+        });
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(discovery_body))
+            .mount(&server)
+            .await;
+
+        // The JWKS never contains the token's key. We expect it to be fetched
+        // twice: once on the initial cache-miss read, and once more after the
+        // unknown `kid` forces a cache-bypassing refetch. The `.expect(2)` is
+        // verified when the server is dropped at the end of the test.
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "keys": [] })),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let db = crate::db::SqliteDatabase::open_in_memory().await.unwrap();
+        let mut config = crate::config::Config::default();
+        config.web.admin.oidc = Some(crate::config::OidcConfig {
+            endpoint: server.uri(),
+            client_id: "client".to_string(),
+            client_secret: "secret".to_string(),
+            scopes: vec![],
+        });
+        let services = crate::services::ServicesContainer::new(config, db);
+        let oidc = services.config().web.admin.oidc.clone().unwrap();
+
+        let token = rs256_token_with_kid("rotated");
+        let result = validate_token(&services, &oidc, &token).await;
+
+        // Verification can't succeed against an empty JWKS, but the refetch must
+        // have been attempted (asserted via the mock's expected hit count).
         assert!(result.is_err());
     }
 }

--- a/agent/src/web/helpers/request.rs
+++ b/agent/src/web/helpers/request.rs
@@ -5,6 +5,8 @@
 //! forwarding headers when we have been explicitly told to trust them. They are
 //! used by both the OIDC admin authentication flow and the OAuth client flow.
 
+use std::net::SocketAddr;
+
 use actix_web::http::header::HeaderMap;
 
 use crate::prelude::Services;
@@ -12,6 +14,35 @@ use crate::prelude::Services;
 /// Returns the value of the named header as a string, if present and valid.
 pub fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
     headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+/// Determines the client IP address to evaluate the admin ACL against.
+///
+/// When the deployment trusts its reverse proxy, the left-most `X-Forwarded-For`
+/// entry (the original client as recorded by the proxy) is used; the left-most
+/// entry mirrors how [`is_https`] reads `X-Forwarded-Proto`. When the proxy is
+/// **not** trusted the header is ignored entirely and the direct socket peer is
+/// used, so a client cannot spoof its address by sending `X-Forwarded-For`.
+///
+/// Because the left-most value is taken, `trust_proxy` must only be enabled
+/// behind a proxy that overwrites (or otherwise sanitises) any inbound
+/// `X-Forwarded-For` from the client, exactly as its configuration documentation
+/// requires.
+pub fn client_ip(
+    trust_proxy: bool,
+    headers: &HeaderMap,
+    peer_addr: Option<SocketAddr>,
+) -> Option<String> {
+    if trust_proxy
+        && let Some(client) = header_str(headers, "x-forwarded-for")
+            .and_then(|forwarded| forwarded.split(',').next())
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+    {
+        return Some(client.to_string());
+    }
+
+    peer_addr.map(|addr| addr.ip().to_string())
 }
 
 /// Determines whether the original request reached us over HTTPS. The
@@ -106,5 +137,43 @@ mod tests {
             Some("http")
         ));
         assert!(is_https(false, &headers(&[]), Some("https")));
+    }
+
+    fn peer(addr: &str) -> Option<SocketAddr> {
+        Some(addr.parse().unwrap())
+    }
+
+    #[test]
+    fn client_ip_uses_forwarded_for_when_trusted() {
+        // The left-most entry is the original client as seen by the trusted proxy.
+        assert_eq!(
+            client_ip(
+                true,
+                &headers(&[("x-forwarded-for", "203.0.113.5, 10.0.0.1")]),
+                peer("10.0.0.1:443")
+            ),
+            Some("203.0.113.5".to_string())
+        );
+        // Falls back to the socket peer when no forwarding header is present.
+        assert_eq!(
+            client_ip(true, &headers(&[]), peer("198.51.100.7:1234")),
+            Some("198.51.100.7".to_string())
+        );
+    }
+
+    #[test]
+    fn client_ip_ignores_forwarded_for_when_proxy_untrusted() {
+        // A spoofed X-Forwarded-For must not override the real socket peer when we
+        // are not configured to trust a proxy — otherwise an attacker could forge
+        // an allow-listed client_ip in the admin ACL.
+        assert_eq!(
+            client_ip(
+                false,
+                &headers(&[("x-forwarded-for", "127.0.0.1")]),
+                peer("203.0.113.9:5555")
+            ),
+            Some("203.0.113.9".to_string())
+        );
+        assert_eq!(client_ip(false, &headers(&[]), None), None);
     }
 }

--- a/agent/src/web/oauth.rs
+++ b/agent/src/web/oauth.rs
@@ -1,10 +1,25 @@
 use crate::prelude::*;
-use actix_web::{HttpResponse, dev::HttpServiceFactory, web};
+use actix_web::body::BoxBody;
+use actix_web::cookie::time::Duration as CookieDuration;
+use actix_web::cookie::{Cookie, SameSite};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::middleware::{Next, from_fn};
+use actix_web::{HttpRequest, HttpResponse, dev::HttpServiceFactory, web};
 use oauth2::{CsrfToken, Scope, TokenResponse};
 use reqwest::Url;
 use serde::Deserialize;
 
 use crate::prelude::Services;
+use crate::web::helpers::oidc::{AdminRequestFilter, filterable_claims, validate_token};
+use crate::web::helpers::request::client_ip;
+
+/// The transient cookie that carries the OAuth setup wizard's CSRF `state` across
+/// the redirect to the provider, so the callback can confirm the response
+/// belongs to a flow this browser actually started.
+const OAUTH_SETUP_STATE_COOKIE: &str = "automate_oauth_setup";
+
+/// How long the OAuth setup wizard's state cookie remains valid.
+const OAUTH_SETUP_STATE_SECONDS: i64 = 10 * 60;
 
 /// Renders a minimal, self-contained HTML page for the server-side OAuth setup
 /// wizard. All interpolated values are HTML-escaped to avoid injection.
@@ -61,8 +76,175 @@ fn not_found() -> HttpResponse {
     )
 }
 
+/// Builds the transient state cookie for the OAuth setup wizard. It is scoped to
+/// the provider's own `/oauth/{provider}` path and `SameSite=Lax` so it is
+/// returned on the provider's top-level redirect back to the callback.
+fn oauth_state_cookie(provider: &str, state: String, secure: bool) -> Cookie<'static> {
+    Cookie::build(OAUTH_SETUP_STATE_COOKIE, state)
+        .path(format!("/oauth/{provider}"))
+        .http_only(true)
+        .secure(secure)
+        .same_site(SameSite::Lax)
+        .max_age(CookieDuration::seconds(OAUTH_SETUP_STATE_SECONDS))
+        .finish()
+}
+
+/// Builds a removal for the OAuth setup wizard's state cookie (one-shot: it is
+/// cleared as soon as the callback resolves, whatever the outcome).
+fn clear_oauth_state_cookie(provider: &str) -> Cookie<'static> {
+    let mut removal = Cookie::build(OAUTH_SETUP_STATE_COOKIE, "")
+        .path(format!("/oauth/{provider}"))
+        .finish();
+    removal.make_removal();
+    removal
+}
+
+/// Attaches the state-cookie removal to a callback response.
+fn with_cleared_state(provider: &str, mut response: HttpResponse) -> HttpResponse {
+    let _ = response.add_cookie(&clear_oauth_state_cookie(provider));
+    response
+}
+
+/// Validates the OAuth `state`: the value echoed back by the provider must equal
+/// the (non-empty) value stored in the browser's state cookie.
+fn state_matches(expected: Option<&str>, provided: Option<&str>) -> bool {
+    matches!((expected, provided), (Some(a), Some(b)) if !a.is_empty() && a == b)
+}
+
+/// The outcome of evaluating wizard access for a request.
+enum WizardOutcome {
+    /// The visitor may proceed.
+    Authorized,
+    /// The visitor isn't signed in and signing in could grant access.
+    NeedsLogin,
+    /// The visitor is denied and signing in would not help.
+    Forbidden,
+}
+
+/// Determines whether a request may use a provider's setup wizard.
+///
+/// A provider that defines its own `acl` opts into self-service access: the ACL
+/// is evaluated directly (a session is consulted when present but never required,
+/// so `acl = 'true'` lets anyone connect). A provider without an `acl` is
+/// admin-gated and behaves exactly like the admin API — when OIDC is configured a
+/// valid session is required before the admin ACL is consulted.
+async fn authorize_wizard<S: Services>(
+    services: &S,
+    req: &HttpRequest,
+    provider_config: Option<&OAuth2Config>,
+) -> WizardOutcome {
+    let config = services.config();
+    let admin = &config.web.admin;
+
+    let (acl, require_session) = match provider_config.and_then(|c| c.acl.as_ref()) {
+        Some(acl) => (acl, false),
+        None => (&admin.acl, true),
+    };
+
+    // Validate the session cookie when OIDC is configured and one is present; an
+    // absent or invalid cookie simply means "not signed in".
+    let claims = match (admin.oidc.as_ref(), req.cookie(super::api::SESSION_COOKIE)) {
+        (Some(oidc), Some(cookie)) => validate_token(services, oidc, cookie.value()).await.ok(),
+        _ => None,
+    };
+
+    // Admin-gated wizards require a valid session before the ACL is consulted,
+    // exactly as the admin API does.
+    if require_session && admin.oidc.is_some() && claims.is_none() {
+        return WizardOutcome::NeedsLogin;
+    }
+
+    let filterable = claims.as_ref().map(filterable_claims);
+    let filter = AdminRequestFilter {
+        method: req.method().as_str(),
+        path: req.path(),
+        client_ip: client_ip(config.web.trust_proxy, req.headers(), req.peer_addr()),
+        headers: req.headers(),
+        claims: filterable.as_ref(),
+    };
+
+    if acl.matches(&filter).unwrap_or(false) {
+        WizardOutcome::Authorized
+    } else if admin.oidc.is_some() && claims.is_none() {
+        // Not signed in, and signing in might supply claims that satisfy the ACL.
+        WizardOutcome::NeedsLogin
+    } else {
+        WizardOutcome::Forbidden
+    }
+}
+
+/// An HTML interstitial prompting the visitor to sign in, returning to the
+/// current wizard URL afterwards. Only shown when OIDC is configured.
+fn sign_in_page(req: &HttpRequest) -> HttpResponse {
+    let return_to = req.uri().to_string();
+    let login = format!(
+        "/api/v1/auth/login?return_to={}",
+        urlencoding::encode(&return_to)
+    );
+    html_action_page(
+        "Sign in | Automate",
+        "Sign in required",
+        "You need to sign in before you can set up this integration.",
+        &login,
+        "Sign in",
+    )
+}
+
+/// An HTML page shown when the visitor is authenticated (or no sign-in is
+/// possible) but not permitted to use the wizard.
+fn access_denied_page() -> HttpResponse {
+    error_page(
+        403,
+        "Access denied",
+        "Your account is not permitted to set up this integration.",
+    )
+}
+
+/// Authentication/authorization gate for the OAuth setup wizard.
+///
+/// Unlike the JSON admin API this renders HTML: an unauthenticated visitor is
+/// offered a sign-in link (rather than a bare `401`), and a denied visitor gets a
+/// readable page. Per-provider `acl`s are honoured via [`authorize_wizard`].
+async fn oauth_wizard_auth<S: Services + Send + Sync + 'static>(
+    req: ServiceRequest,
+    next: Next<BoxBody>,
+) -> Result<ServiceResponse<BoxBody>, actix_web::Error> {
+    let Some(services) = req.app_data::<web::Data<S>>().cloned() else {
+        return Ok(req.into_response(error_page(
+            500,
+            "Internal Server Error",
+            "Service context unavailable.",
+        )));
+    };
+
+    // The scope is `/oauth/{provider}`; read the provider straight from the path
+    // so we don't depend on route-level match extraction in the middleware.
+    let provider = req
+        .path()
+        .strip_prefix("/oauth/")
+        .and_then(|rest| rest.split('/').next())
+        .unwrap_or("");
+    let provider_config = services.config().oauth2.get(provider).cloned();
+
+    match authorize_wizard(services.as_ref(), req.request(), provider_config.as_ref()).await {
+        WizardOutcome::Authorized => next.call(req).await,
+        WizardOutcome::NeedsLogin => {
+            let response = sign_in_page(req.request());
+            Ok(req.into_response(response))
+        }
+        WizardOutcome::Forbidden => Ok(req.into_response(access_denied_page())),
+    }
+}
+
 pub fn configure<S: Services + Send + Sync + 'static>() -> impl HttpServiceFactory {
     web::scope("/oauth/{provider}")
+        // The setup wizard performs privileged actions (linking external accounts
+        // the agent then acts on), so gate it behind an authentication/ACL check.
+        // By default that is the admin gate, but a provider may set its own `acl`
+        // to allow self-service sign-up. The flow is browser-driven via top-level
+        // GET navigations, so any session cookie is carried even on the provider's
+        // cross-site redirect back to `/callback`.
+        .wrap(from_fn(oauth_wizard_auth::<S>))
         .route("/", web::get().to(oauth_home::<S>))
         .route("/authorize", web::get().to(oauth_authorize::<S>))
         .route("/callback", web::get().to(oauth_callback::<S>))
@@ -106,9 +288,19 @@ async fn oauth_authorize<S: Services + Send + Sync + 'static>(
                 info!("Initiating OAuth2 login flow for provider '{}'", &*provider);
 
                 match cfg.get_login_url(format!("{base_url}/oauth/{provider}/callback")) {
-                    Ok(url) => actix_web::HttpResponse::Found()
-                        .append_header((actix_web::http::header::LOCATION, url.to_string()))
-                        .finish(),
+                    Ok((url, state)) => {
+                        // Persist the CSRF `state` in the browser so the callback
+                        // can verify it; mark the cookie `Secure` over HTTPS.
+                        let secure = super::helpers::request::is_https(
+                            services.config().web.trust_proxy,
+                            req.headers(),
+                            req.uri().scheme_str(),
+                        );
+                        actix_web::HttpResponse::Found()
+                            .cookie(oauth_state_cookie(&provider, state, secure))
+                            .append_header((actix_web::http::header::LOCATION, url.to_string()))
+                            .finish()
+                    }
                     Err(e) => {
                         error!("Failed to get OAuth login URL: {}", e);
                         sentry::capture_error(&e);
@@ -148,72 +340,106 @@ async fn oauth_callback<S: Services + Send + Sync + 'static>(
     req: actix_web::HttpRequest,
     query: web::Query<std::collections::HashMap<String, String>>,
 ) -> actix_web::HttpResponse {
-    if let Some(base_url) =
+    let Some(base_url) =
         super::helpers::request::base_url(services.as_ref(), req.headers(), req.uri().scheme_str())
-    {
-        if let Some(config) = services.config().oauth2.get(&*provider).cloned() {
-            if let Some(code) = query.get("code") {
-                match config
-                    .handle_callback(
-                        format!("{base_url}/oauth/{provider}/callback"),
-                        code.clone(),
-                        &services.http_client(),
-                    )
-                    .await
-                {
-                    Ok(token) => {
-                        let partitions = config.jobs.clone();
-                        for partition in partitions.into_iter() {
-                            if let Err(e) = services
-                                .queue()
-                                .enqueue(partition, token.clone(), None, None)
-                                .await
-                            {
-                                error!("Failed to enqueue OAuth token storage task: {}", e);
-                                return error_page(
-                                    500,
-                                    "Internal Server Error",
-                                    "Failed to store OAuth token, please try again later.",
-                                );
-                            }
-                        }
-
-                        html_page(
-                            200,
-                            &format!("{} | Automate", config.name),
-                            "Login Complete",
-                            &format!(
-                                "You have successfully completed setting up {}, you can close this window.",
-                                config.name
-                            ),
-                        )
-                    }
-                    Err(e) => {
-                        error!("OAuth callback handling failed: {}", e);
-                        sentry::capture_error(&e);
-                        return error_page(
-                            500,
-                            "Internal Server Error",
-                            "Failed to complete OAuth token exchange.",
-                        );
-                    }
-                }
-            } else {
-                return error_page(
-                    400,
-                    "Bad Request",
-                    "Missing 'code' parameter in OAuth callback.",
-                );
-            }
-        } else {
-            return error_page(400, "Bad Request", "Invalid OAuth provider specified.");
-        }
-    } else {
-        error_page(
+    else {
+        return error_page(
             400,
             "Bad Request",
             "Your request did not include the required Host header.",
+        );
+    };
+
+    let Some(config) = services.config().oauth2.get(&*provider).cloned() else {
+        return error_page(400, "Bad Request", "Invalid OAuth provider specified.");
+    };
+
+    // CSRF: the `state` echoed back by the provider must match the value we stored
+    // in the browser's state cookie when the flow began. Without this an attacker
+    // could trick a signed-in admin into completing the flow with an authorization
+    // code of the attacker's choosing, linking the attacker's account to the agent.
+    let expected_state = req
+        .cookie(OAUTH_SETUP_STATE_COOKIE)
+        .map(|c| c.value().to_string());
+    if !state_matches(
+        expected_state.as_deref(),
+        query.get("state").map(String::as_str),
+    ) {
+        warn!("Rejected an OAuth setup callback with a missing or mismatched state.");
+        return with_cleared_state(
+            &provider,
+            error_page(
+                400,
+                "Bad Request",
+                "The login could not be verified. Please start the setup again.",
+            ),
+        );
+    }
+
+    let Some(code) = query.get("code") else {
+        return with_cleared_state(
+            &provider,
+            error_page(
+                400,
+                "Bad Request",
+                "Missing 'code' parameter in OAuth callback.",
+            ),
+        );
+    };
+
+    match config
+        .handle_callback(
+            format!("{base_url}/oauth/{provider}/callback"),
+            code.clone(),
+            &services.http_client(),
         )
+        .await
+    {
+        Ok(token) => {
+            let partitions = config.jobs.clone();
+            for partition in partitions.into_iter() {
+                if let Err(e) = services
+                    .queue()
+                    .enqueue(partition, token.clone(), None, None)
+                    .await
+                {
+                    error!("Failed to enqueue OAuth token storage task: {}", e);
+                    return with_cleared_state(
+                        &provider,
+                        error_page(
+                            500,
+                            "Internal Server Error",
+                            "Failed to store OAuth token, please try again later.",
+                        ),
+                    );
+                }
+            }
+
+            with_cleared_state(
+                &provider,
+                html_page(
+                    200,
+                    &format!("{} | Automate", config.name),
+                    "Login Complete",
+                    &format!(
+                        "You have successfully completed setting up {}, you can close this window.",
+                        config.name
+                    ),
+                ),
+            )
+        }
+        Err(e) => {
+            error!("OAuth callback handling failed: {}", e);
+            sentry::capture_error(&e);
+            with_cleared_state(
+                &provider,
+                error_page(
+                    500,
+                    "Internal Server Error",
+                    "Failed to complete OAuth token exchange.",
+                ),
+            )
+        }
     }
 }
 
@@ -224,6 +450,16 @@ pub struct OAuth2Config {
     #[serde(default)]
     pub jobs: Vec<String>,
 
+    /// Optional access-control filter governing who may use this provider's setup
+    /// wizard. It is evaluated exactly like the admin ACL — against the request
+    /// `method`, `path`, `client_ip`, `headers.*`, and (when OIDC is configured
+    /// and the visitor is signed in) `claims.*`. When omitted the wizard is
+    /// admin-gated: it falls back to the admin ACL and requires admin sign-in,
+    /// just like the rest of the admin area. Set `acl = 'true'` to let anyone
+    /// connect this provider without signing in.
+    #[serde(default)]
+    pub acl: Option<Filter>,
+
     pub client_id: String,
     pub client_secret: String,
     pub auth_url: String,
@@ -233,7 +469,10 @@ pub struct OAuth2Config {
 }
 
 impl OAuth2Config {
-    pub fn get_login_url(&self, redirect_url: impl ToString) -> Result<Url, human_errors::Error> {
+    pub fn get_login_url(
+        &self,
+        redirect_url: impl ToString,
+    ) -> Result<(Url, String), human_errors::Error> {
         let client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(self.client_id.clone()))
             .set_client_secret(oauth2::ClientSecret::new(self.client_secret.clone()))
             .set_auth_uri(oauth2::AuthUrl::new(self.auth_url.clone()).or_user_err(&[
@@ -248,12 +487,11 @@ impl OAuth2Config {
                 ])?,
             );
 
-        let (url, _csrf) = client
+        let (url, csrf) = client
             .authorize_url(CsrfToken::new_random)
             .add_scopes(self.scopes.iter().cloned().map(Scope::new))
-            .url()
-            .clone();
-        Ok(url)
+            .url();
+        Ok((url, csrf.secret().clone()))
     }
 
     pub async fn handle_callback(
@@ -360,5 +598,145 @@ impl OAuth2RefreshToken {
 
     pub fn access_token(&self) -> &str {
         &self.access_token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import the actix test utilities under an alias: a bare `test` import would
+    // shadow the built-in `#[test]` attribute with actix's async test macro.
+    use super::*;
+    use actix_web::http::StatusCode;
+    use actix_web::test as actix_test;
+    use actix_web::{App, web};
+
+    use crate::config::Config;
+    use crate::db::SqliteDatabase;
+    use crate::filter::Filter;
+    use crate::services::ServicesContainer;
+
+    #[test]
+    fn state_matches_requires_both_present_nonempty_and_equal() {
+        assert!(state_matches(Some("abc"), Some("abc")));
+        assert!(!state_matches(Some("abc"), Some("def")));
+        assert!(!state_matches(None, Some("abc")));
+        assert!(!state_matches(Some("abc"), None));
+        assert!(!state_matches(Some(""), Some("")));
+    }
+
+    #[test]
+    fn oauth2_config_parses_optional_acl() {
+        let with_acl: OAuth2Config = toml::from_str(
+            r#"
+                name = "Spotify"
+                client_id = "x"
+                client_secret = "y"
+                auth_url = "https://accounts.spotify.com/authorize"
+                token_url = "https://accounts.spotify.com/api/token"
+                acl = 'client_ip in ["127.0.0.1"]'
+            "#,
+        )
+        .unwrap();
+        assert!(with_acl.acl.is_some());
+
+        let without_acl: OAuth2Config = toml::from_str(
+            r#"
+                name = "Spotify"
+                client_id = "x"
+                client_secret = "y"
+                auth_url = "https://accounts.spotify.com/authorize"
+                token_url = "https://accounts.spotify.com/api/token"
+            "#,
+        )
+        .unwrap();
+        assert!(without_acl.acl.is_none());
+    }
+
+    /// Services with a single OAuth provider configured, the given admin ACL, and
+    /// an optional provider-specific ACL.
+    async fn service_with_provider(
+        admin_acl: &str,
+        provider_acl: Option<&str>,
+    ) -> ServicesContainer<SqliteDatabase> {
+        let db = SqliteDatabase::open_in_memory().await.unwrap();
+        let mut config = Config::default();
+        config.web.admin.acl = Filter::new(admin_acl).unwrap();
+        // A fixed base URL so the callback doesn't depend on a Host header.
+        config.web.base_url = Some("http://localhost:8080".to_string());
+        config.oauth2.insert(
+            "spotify".to_string(),
+            OAuth2Config {
+                name: "Spotify".to_string(),
+                jobs: vec![],
+                acl: provider_acl.map(|a| Filter::new(a).unwrap()),
+                client_id: "client".to_string(),
+                client_secret: "secret".to_string(),
+                auth_url: "https://accounts.spotify.com/authorize".to_string(),
+                token_url: "https://accounts.spotify.com/api/token".to_string(),
+                scopes: vec![],
+            },
+        );
+        ServicesContainer::new(config, db)
+    }
+
+    async fn wizard_home_status(services: ServicesContainer<SqliteDatabase>) -> StatusCode {
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(services))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+        let req = actix_test::TestRequest::get()
+            .uri("/oauth/spotify/")
+            .to_request();
+        actix_test::call_service(&app, req).await.status()
+    }
+
+    #[actix_web::test]
+    async fn setup_wizard_requires_admin_auth_by_default() {
+        // No provider ACL, deny-all admin ACL, OIDC off ⇒ access denied (403).
+        assert_eq!(
+            wizard_home_status(service_with_provider("false", None).await).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[actix_web::test]
+    async fn setup_wizard_provider_acl_allows_anyone() {
+        // A provider ACL of `true` lets anyone connect even though the admin area
+        // is locked down (admin ACL `false`, no sign-in).
+        assert_eq!(
+            wizard_home_status(service_with_provider("false", Some("true")).await).await,
+            StatusCode::OK
+        );
+    }
+
+    #[actix_web::test]
+    async fn setup_wizard_provider_acl_can_deny_despite_open_admin() {
+        // A provider ACL overrides the admin ACL in both directions: here it denies
+        // even though the admin ACL would allow.
+        assert_eq!(
+            wizard_home_status(service_with_provider("true", Some("false")).await).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[actix_web::test]
+    async fn setup_wizard_callback_rejects_missing_state() {
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(service_with_provider("true", None).await))
+                .service(configure::<ServicesContainer<SqliteDatabase>>()),
+        )
+        .await;
+
+        // Auth passes, but with no state cookie the CSRF check must reject the
+        // callback before any authorization-code exchange is attempted.
+        let req = actix_test::TestRequest::get()
+            .uri("/oauth/spotify/callback?code=abc&state=xyz")
+            .to_request();
+        let resp = actix_test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/agent/src/web/telemetry.rs
+++ b/agent/src/web/telemetry.rs
@@ -12,6 +12,78 @@ use futures::{
 use opentelemetry::propagation::Extractor;
 use tracing_batteries::prelude::*;
 
+/// Query-string parameters whose values carry credentials or single-use secrets
+/// and must never be written to a span. The most important here are the OAuth /
+/// OIDC `code` and `state` returned on the auth callback.
+const SENSITIVE_QUERY_PARAMS: &[&str] = &[
+    "code",
+    "state",
+    "id_token",
+    "access_token",
+    "refresh_token",
+    "token",
+    "client_secret",
+];
+
+/// Request headers whose values carry credentials and must be redacted from the
+/// span's header dump. `cookie` holds the session ID token; `authorization`
+/// holds any bearer token; `x-csrf-token` is the double-submit secret.
+const SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-csrf-token",
+];
+
+/// Renders the request target (path + query) for the span, redacting the values
+/// of any [`SENSITIVE_QUERY_PARAMS`] so secrets such as the OIDC `code`/`state`
+/// never land in telemetry. Parameter names are preserved so the shape of the
+/// request is still legible.
+fn redact_target(uri: &actix_web::http::Uri) -> String {
+    match uri.query() {
+        None => uri.path().to_string(),
+        Some(query) => {
+            let redacted = query
+                .split('&')
+                .map(|pair| {
+                    let name = pair.split('=').next().unwrap_or(pair);
+                    if SENSITIVE_QUERY_PARAMS
+                        .iter()
+                        .any(|p| name.eq_ignore_ascii_case(p))
+                    {
+                        format!("{name}=REDACTED")
+                    } else {
+                        pair.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}?{}", uri.path(), redacted)
+        }
+    }
+}
+
+/// Renders the request headers for the span, redacting the values of any
+/// [`SENSITIVE_HEADERS`] (the session cookie, authorization tokens, and the CSRF
+/// secret) while keeping every header name for debugging.
+fn redact_headers(headers: &HeaderMap) -> String {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            if SENSITIVE_HEADERS
+                .iter()
+                .any(|h| name.as_str().eq_ignore_ascii_case(h))
+            {
+                format!("{name}: REDACTED")
+            } else {
+                format!("{name}: {value:?}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub struct TracingLogger;
 
 impl<S, B> Transform<S, ServiceRequest> for TracingLogger
@@ -55,18 +127,24 @@ where
             .and_then(|h| h.to_str().ok())
             .unwrap_or("");
 
+        // Redact secrets before they reach the span: the request target can carry
+        // the OAuth/OIDC `code` and `state` query parameters, and the header dump
+        // would otherwise include the session cookie and any Authorization token.
+        let http_target = redact_target(req.uri());
+        let http_headers = redact_headers(req.headers());
+
         let span = info_span!(
             "request",
             "otel.kind" = "server",
             "otel.name" = req.match_pattern().unwrap_or_else(|| req.uri().path().to_string()),
             "net.transport" = "IP.TCP",
             "net.peer.ip" = %req.connection_info().realip_remote_addr().unwrap_or(""),
-            "http.target" = %req.uri(),
+            "http.target" = %http_target,
             "http.user_agent" = %user_agent,
             "http.status_code" = EmptyField,
             "http.method" = %req.method(),
             "http.url" = %req.match_pattern().unwrap_or_else(|| req.path().into()),
-            "http.headers" = %req.headers().iter().map(|(k, v)| format!("{k}: {v:?}")).collect::<Vec<_>>().join("\n"),
+            "http.headers" = %http_headers,
         );
 
         // Propagate OpenTelemetry parent span context information
@@ -117,5 +195,59 @@ impl<'a> Extractor for HeaderMapExtractor<'a> {
 
     fn keys(&self) -> Vec<&str> {
         self.headers.keys().map(|v| v.as_str()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::Uri;
+    use actix_web::http::header::{HeaderName, HeaderValue};
+
+    #[test]
+    fn redact_target_redacts_oidc_code_and_state() {
+        let uri: Uri = "/api/v1/auth/callback?code=secret-code&state=secret-state"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            redact_target(&uri),
+            "/api/v1/auth/callback?code=REDACTED&state=REDACTED"
+        );
+    }
+
+    #[test]
+    fn redact_target_keeps_non_sensitive_parameters() {
+        let uri: Uri = "/api/v1/kv/cache?key=oidc%3Ajwks".parse().unwrap();
+        assert_eq!(redact_target(&uri), "/api/v1/kv/cache?key=oidc%3Ajwks");
+
+        let uri: Uri = "/admin".parse().unwrap();
+        assert_eq!(redact_target(&uri), "/admin");
+
+        // A bare flag parameter (no `=`) is preserved verbatim.
+        let uri: Uri = "/?demo".parse().unwrap();
+        assert_eq!(redact_target(&uri), "/?demo");
+    }
+
+    #[test]
+    fn redact_headers_redacts_credentials_but_keeps_names() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("cookie"),
+            HeaderValue::from_static("automate_session=super-secret-jwt"),
+        );
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer super-secret"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-custom"),
+            HeaderValue::from_static("visible"),
+        );
+
+        let rendered = redact_headers(&headers);
+        assert!(rendered.contains("cookie: REDACTED"));
+        assert!(rendered.contains("authorization: REDACTED"));
+        assert!(!rendered.contains("super-secret"));
+        assert!(rendered.contains("x-custom: \"visible\""));
     }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,12 @@ api_key = "${{ env.ALPHAVANTAGE_API_KEY }}"
 [oauth2.spotify]
 name = "Spotify"
 jobs = ["workflow/spotify-yearly-playlist"]
+# The setup wizard at /oauth/spotify/ is admin-gated by default (you must sign in
+# as an admin to link the account). To let other people connect their own account,
+# set an `acl` here. It is evaluated like the admin ACL (`client_ip`, `method`,
+# `path`, `headers.*`, and, when OIDC is configured and the visitor is signed in,
+# `claims.*`). For example, `acl = 'true'` lets anyone connect without signing in.
+# acl = 'true'
 client_id = "${{ env.SPOTIFY_CLIENT_ID }}"
 client_secret = "${{ env.SPOTIFY_CLIENT_SECRET }}"
 auth_url = "https://accounts.spotify.com/authorize"

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -44,6 +44,9 @@ pub enum AuthStatus {
     SignedIn(AdminUser),
     /// Authentication is required; the browser must start the login flow.
     NeedsLogin,
+    /// Access was refused by the admin ACL. Signing in cannot change the outcome
+    /// (and, when OIDC is disabled, is not possible), so the UI must not offer it.
+    Forbidden,
     /// Resolving the authentication state failed.
     Error(String),
 }
@@ -80,6 +83,7 @@ fn use_auth() -> AuthHandle {
                     Ok(Some(user)) => status.set(AuthStatus::SignedIn(user)),
                     Ok(None) => status.set(AuthStatus::Disabled),
                     Err(ApiError::Unauthorized) => status.set(AuthStatus::NeedsLogin),
+                    Err(ApiError::Forbidden) => status.set(AuthStatus::Forbidden),
                     Err(e) => status.set(AuthStatus::Error(e.to_string())),
                 }
             });

--- a/ui/src/pages/protected.rs
+++ b/ui/src/pages/protected.rs
@@ -22,6 +22,14 @@ pub fn protected(props: &ProtectedProps) -> Html {
             <p class="loading-note">{ "Loading…" }</p>
         },
         AuthStatus::NeedsLogin => html! { <Login /> },
+        AuthStatus::Forbidden => html! {
+            <Alert
+                kind={AlertKind::Error}
+                title="Access denied"
+                message="Your request was not permitted by the admin access-control policy. \
+                    If this is unexpected, check the agent's `[web.admin]` acl configuration."
+            />
+        },
         AuthStatus::Error(msg) => {
             let onclick = Callback::from(|_: MouseEvent| {
                 if let Some(window) = web_sys::window() {


### PR DESCRIPTION
## What & why

A review of the auth code (prompted by findings in a sibling project) surfaced several issues in the server-driven OIDC admin auth, and the OAuth *setup wizard* at `/oauth/<provider>` was unauthenticated. This PR fixes those and adds authentication for the wizard.

## Admin API / middleware
- **ACL denial is now `403`, not `401`.** With OIDC disabled a denied request previously returned `401`, so the SPA offered a "Sign in" button that looped back to the landing page forever. By the time the ACL is evaluated, auth is already resolved (or impossible), so a denial is permanent → `403`. The UI gains a matching `Forbidden` state showing a clear "access denied" message.
- **Logout is now CSRF-protected.** `POST /api/v1/auth/logout` lived in the public scope, outside the CSRF middleware, so a cross-site POST could force a logout (the response clears the session cookie regardless of `SameSite`). It now enforces the same double-submit token.
- **`client_ip` honours `trust_proxy`.** The admin ACL's `client_ip` used the raw socket peer, so behind a proxy it always saw the proxy IP (and a localhost-proxy + `client_ip in ["127.0.0.1"]` would treat everyone as localhost). It now reads the left-most `X-Forwarded-For` only when `web.trust_proxy` is set, and the socket peer otherwise (un-spoofable by default).

## OIDC
- **Refetch JWKS on unknown `kid`.** A provider key rotation used to lock out all valid sessions until the 1h cache expired (re-signing in didn't help — same new `kid`). `validate_token` now refetches the JWKS once, bypassing the cache, when a token's `kid` is unknown.
- **JWKS cache TTL 1h → 24h**, now safe thanks to the on-demand refetch.

## Telemetry
- **Redact secrets from request spans.** `http.target` carried the OIDC `code`/`state` query params, and `http.headers` dumped *every* header — including the `Cookie` (session ID-token JWT), `Authorization`, and `X-CSRF-Token`. Values for those params/headers are now redacted (names kept for debugging).

## OAuth setup wizard (`/oauth/<provider>`)
- **CSRF `state`.** The flow generated a `state` then discarded it; it's now stored in a short-lived, `HttpOnly`, `SameSite=Lax` cookie and validated on the callback, preventing login/code-injection CSRF.
- **Authentication gate with HTML UX.** The wizard is gated like the admin area, but renders an HTML sign-in prompt / access-denied page instead of raw JSON.
- **Per-provider `acl`.** Each `[oauth2.<provider>]` may set its own `acl` (evaluated like the admin ACL). `acl = 'true'` enables self-service sign-up (no admin login); omitting it keeps the provider admin-gated. The provider ACL overrides the admin ACL in both directions.

## Reviewer notes
- `trust_proxy` uses the **left-most** `X-Forwarded-For` entry (consistent with the existing `is_https` helper), so it must only be enabled behind a proxy that sanitises inbound `X-Forwarded-For`.
- The wizard's per-provider ACL makes the session **optional** (so `true` means "anybody"); the admin-gated fallback still requires sign-in when OIDC is on, matching prior behaviour.

## Tests
`cargo test -p automate` → 351 passing (new coverage for telemetry redaction, `client_ip`, the 401→403 + logout-CSRF middleware behaviour, JWKS refetch-on-rotation via wiremock, and the OAuth wizard auth/ACL/state). `cargo clippy` and `cargo fmt --check` clean; UI type-checks for `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
