### PR TITLE
ci: fix rust cache for cross (arm64) build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -214,6 +214,16 @@ jobs:
       - name: cargo build
         run: ${{ matrix.builder }} build --release --target ${{ matrix.target }} ${{ matrix.cargo-flags }}
 
+      # cross runs the compiler inside a Docker container as root, so the
+      # registry downloads and build artifacts it writes into the cached
+      # directories end up owned by root. Swatinem/rust-cache's save step runs
+      # as the unprivileged runner user and cannot prune root-owned files,
+      # which causes the cache save to fail and the cross build to never be
+      # cached. Reclaim ownership so the cache can be persisted.
+      - name: Reclaim cache ownership from cross
+        if: matrix.builder == 'cross'
+        run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
+
       - name: Upload GitHub Release Artifacts
         uses: SierraSoftworks/gh-releases@v1.0.9
         if: github.event_name == 'release'


### PR DESCRIPTION
## Problem

The `aarch64-unknown-linux-musl` (linux-arm64) build in `rust.yml` isn't benefiting from the `Swatinem/rust-cache` setup — every run starts from a cold cache, slowing builds down considerably compared to the other targets.

## Root cause

That target is the only one built with **`cross`**. `cross` compiles inside a Docker container running as **root**, and it:

- bind-mounts the host cargo registry (`~/.cargo/registry`, `~/.cargo/git`), and
- writes build artifacts into the host's `./target` directory

…which are exactly the paths `Swatinem/rust-cache` caches. Because the container runs as root, every file `cross` writes into those directories ends up owned by `root:root`.

`rust-cache`'s post-job **save** step runs as the unprivileged `runner` user and must prune/clean those directories before archiving them. It can't modify root-owned files, so the save step fails and **no cache is ever stored** for the cross target. As a result, restores always miss and the arm64 build recompiles everything from scratch on every run.

The other targets (`cargo` builders) run as the runner user directly, so they're unaffected — which is why only the cross build sees no caching benefit.

## Fix

After the cross build, reclaim ownership of the cached paths so `rust-cache`'s save step can prune and persist them:

```yaml
- name: Reclaim cache ownership from cross
  if: matrix.builder == 'cross'
  run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
```

The step is gated to `matrix.builder == 'cross'` so it only runs where it's needed. On subsequent runs the cache restores files owned by the runner, keeping the cycle stable.

https://claude.ai/code/session_01D8p4hMgk4j7FA5oao3Su25

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8p4hMgk4j7FA5oao3Su25)_