### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -374,3 +374,18 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs:
+      - build
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aliases: major minor


### PR DESCRIPTION
Add a release-only fan-in job (needs build) that runs after the build matrix has uploaded its release artifacts. It calls SierraSoftworks/actions-tap to update the automate formula in the Homebrew tap, generating major and minor versioned aliases so users can pin to a major or minor line. The job is guarded with `if: github.event_name == 'release'` so it never runs on push or pull_request events.