### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ it also handles webhooks from services like Tailscale, Honeycomb,
 and [Grey](https://github.com/SierraSoftworks/grey) (raising a Todoist
 task when a monitor becomes unhealthy and completing it once it recovers).
 
+## Installation
+
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/automate
+```
+
 ## Configuration
 
 Automate is configured via a `config.toml` file. An example


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/automate

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
