### PR TITLE
feat(telemetry): report job and internal failures to Sentry

### DIFF
--- a/agent/src/job.rs
+++ b/agent/src/job.rs
@@ -310,8 +310,16 @@ impl JobHost {
                             item.partition,
                             item.payload
                         );
+                        sentry::capture_message(
+                            &format!(
+                                "No job handler is registered for partition '{}'; dropping the message.",
+                                item.partition
+                            ),
+                            sentry::Level::Warning,
+                        );
                         if let Err(err) = queue.complete(item.partition.clone(), item).await {
                             error!(error = %err, "Failed to drop unhandled job message: {err}");
+                            sentry::capture_error(&err);
                         }
                         continue;
                     };
@@ -325,6 +333,7 @@ impl JobHost {
                 }
                 Err(err) => {
                     error!(error = %err, "An error occurred while fetching a job from the queue: {err}");
+                    sentry::capture_error(&err);
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
             }
@@ -356,6 +365,7 @@ impl JobHost {
             .await
         {
             warn!(error = %err, "Failed to set the reservation window for job '{name}': {err}");
+            sentry::capture_error(&err);
         }
 
         let span = info_span!(
@@ -402,6 +412,7 @@ impl JobHost {
                 info!("Job '{name}' completed successfully (traceparent: {traceparent}).");
                 if let Err(err) = queue.complete(name.to_string(), item).await {
                     error!(error = %err, "Failed to mark job '{name}' as completed (traceparent: {traceparent}): {err}");
+                    sentry::capture_error(&err);
                 }
             }
             Err(err) => {

--- a/agent/src/web/api/auth.rs
+++ b/agent/src/web/api/auth.rs
@@ -86,6 +86,7 @@ pub async fn auth_login<S: Services>(
         Ok(d) => d,
         Err(e) => {
             error!("Failed to load OIDC discovery document during login: {e}");
+            sentry::capture_error(&e);
             return json_error(
                 actix_web::http::StatusCode::BAD_GATEWAY,
                 "We could not reach the configured identity provider.",
@@ -100,6 +101,7 @@ pub async fn auth_login<S: Services>(
         Ok(url) => url,
         Err(e) => {
             error!("Failed to build the OIDC authorization URL: {e}");
+            sentry::capture_error(&e);
             return json_error(
                 actix_web::http::StatusCode::BAD_GATEWAY,
                 "We could not start the sign-in with the identity provider.",
@@ -117,6 +119,7 @@ pub async fn auth_login<S: Services>(
         Ok(value) => value,
         Err(e) => {
             error!("Failed to serialize the OAuth state cookie: {e}");
+            sentry::capture_error(&e);
             return json_error(
                 actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
                 "We could not start the sign-in process.",
@@ -188,6 +191,7 @@ pub async fn auth_callback<S: Services>(
         Ok(d) => d,
         Err(e) => {
             error!("Failed to load OIDC discovery document during callback: {e}");
+            sentry::capture_error(&e);
             return clear_oauth_and_redirect("/?auth_error=provider");
         }
     };

--- a/agent/src/web/oauth.rs
+++ b/agent/src/web/oauth.rs
@@ -404,6 +404,7 @@ async fn oauth_callback<S: Services + Send + Sync + 'static>(
                     .await
                 {
                     error!("Failed to enqueue OAuth token storage task: {}", e);
+                    sentry::capture_error(&e);
                     return with_cleared_state(
                         &provider,
                         error_page(


### PR DESCRIPTION
## Summary

Several failure paths were only recorded to `tracing` and never reached Sentry, so operational failures in the job host and the OIDC/OAuth flows went unnoticed. This change captures those failures explicitly, alongside the existing log calls.

The Sentry battery from `tracing-batteries` only calls `sentry::init` — it does **not** install a `sentry-tracing` layer, and the OpenTelemetry battery owns the global subscriber. So every Sentry event must be an explicit `capture_*` call; `error!`/`warn!` alone never reaches Sentry.

## What's now captured

**Job host (`agent/src/job.rs`)** — the consumer loop never returns, so its per-iteration failures previously never bubbled to the top-level error reporter:
- No handler registered for a partition (message gets dropped) → `capture_message` at `Warning`
- Failed to drop an unhandled message
- Queue dequeue error
- Failed to set the reservation window
- Failed to mark a job as completed

**Web internal failures:**
- `web/oauth.rs` — failed to enqueue the OAuth token storage task
- `web/api/auth.rs` — OIDC discovery (login + callback), authorization-URL build, and state-cookie serialization failures

## Deliberately left as tracing-only

- **Job user-errors** (`Kind::User`) — the existing system-vs-user distinction is preserved; only `Kind::System` errors go to Sentry, so user misconfiguration does not generate noise.
- **Client/external-input 4xx paths** (`warn!`-level) — webhook body-read failures and OIDC token-exchange / ID-token validation are client-side, not internal failures.

## Testing

- `cargo check` passes (one pre-existing unrelated warning).
- `cargo test --bin automate job::` — 5 passing. `capture_*` calls are safe no-ops when no Sentry client is initialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)